### PR TITLE
Adds global exclude rule action.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,21 @@ var rules = [
     dest: 'dest/file'
   },
 
-  // 2.3 Search and Replace in Files
+  // 2.3 Exclude files from all subsequent searches
+  {
+    action: 'exclude',
+    files: ['A.txt', 'B.dmg']
+  },
+
+  // 2.4 Search and Replace in Files
   //     Note: this is applied globally to all files in the root directory
   {
     action: 'replace',
     search: 'foo',
     replace: 'bar',
 
-    // Use `exclude` property to define a set of files / lines to exclude
-    // from the global replace.
+    // Use `exclude` property to define a set of files / lines to ignore
+    // from this particular search and replace
     exclude: [
       {
         name: 'another/file',

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -42,10 +42,12 @@ function Transformer(root, rules) {
   this.commands = [];
   this.results = [];
   this.nameChanges = [];
+  this._globalExcludes = [];
 
   this.setAction('copy', this.copy);
   this.setAction('rename', this.rename);
   this.setAction('replace', this.replace);
+  this.setAction('exclude', this.exclude);
 }
 
 /**
@@ -434,7 +436,7 @@ Transformer.prototype.replace = function (rule, cb) {
   this.driver.grep(rule.search, function (err, grepResult) {
     var files = [];
 
-    // 1. Determine files & lines from grep
+    // 1. Determine files & lines from grep and filter out global excludes
     grepResult.split('\n').forEach(function (line) {
       var match = line.match(/(.*):(\d+):.*/);
       if (match) {
@@ -449,6 +451,11 @@ Transformer.prototype.replace = function (rule, cb) {
     }
 
     // 2. Remove excluded files/lines from result set
+
+    // 2.0 Filter out global excludes
+    files = files.filter(function (file) {
+      return !~self._globalExcludes.indexOf(file.name);
+    });
 
     // 2.1 Keep track of when excludes are used to filter results
     var ruleApplied = [];
@@ -554,4 +561,31 @@ Transformer.prototype.replace = function (rule, cb) {
       }
     ], cb);
   });
+};
+
+/**
+ * Global exclude rule. Causes given files to be ignored by all subsequent
+ * rules.
+ * @param {object} rule Rule that provides a list of files to exclude.
+ * @param {function} cb Callback to execute once the exclude rules have been
+ *   applied.
+ */
+Transformer.prototype.exclude = function (rule, cb) {
+  if (!Array.isArray(rule.files)) {
+    this.addWarning('Exclude files not specified as an array.');
+    return cb();
+  }
+
+  var self = this;
+  rule.files.forEach(function (name) {
+    if (!isString(name)) {
+      self.addWarning('Non-string exclude filename encountered.');
+      return;
+    }
+    var absoluteName = self.driver.absolutePath(name);
+    if (!~self._globalExcludes.indexOf(absoluteName)) {
+      self._globalExcludes.push(absoluteName);
+    }
+  });
+  cb();
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -403,7 +403,7 @@ Transformer.prototype.replace = function (rule, cb) {
   this.driver.grep(rule.search, function (err, grepResult) {
     var files = [];
 
-    // 1. Determine files & lines from grep and filter out global excludes
+    // 1. Determine files & lines from grep
     grepResult.split('\n').forEach(function (line) {
       var match = line.match(/(.*):(\d+):.*/);
       if (match) {

--- a/test/transformer/constructor.js
+++ b/test/transformer/constructor.js
@@ -62,5 +62,11 @@ describe('Transformer', function() {
       expect(transformer.nameChanges).to.be.an.array();
       done();
     });
+
+    it('should keep a list of global file excludes', function(done) {
+      var transformer = new Transformer('/etc', []);
+      expect(transformer._globalExcludes).to.be.an.array();
+      done();
+    });
   }); // end 'constructor'
 });

--- a/test/transformer/exclude.js
+++ b/test/transformer/exclude.js
@@ -1,0 +1,82 @@
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var beforeEach = lab.beforeEach;
+var afterEach = lab.afterEach;
+var expect = require('code').expect;
+var sinon = require('sinon');
+
+var Transformer = require('../../lib/transformer');
+
+describe('Transformer', function() {
+  describe('exclude', function() {
+    var transformer;
+
+    beforeEach(function (done) {
+      transformer = new Transformer('/etc', []);
+      sinon.stub(transformer, 'addWarning');
+      done();
+    });
+
+    it('should generate a warning if not given an array of file names', function(done) {
+      var rule = { action: 'exclude' };
+      transformer.exclude(rule, function (err) {
+        if (err) { return done(err); }
+        expect(transformer.addWarning.calledOnce).to.be.true();
+        expect(transformer.addWarning.calledWith(
+          'Exclude files not specified as an array.'
+        )).to.be.true();
+        done();
+      });
+    });
+
+    it('should generate a warning if a file name is not a string.', function(done) {
+      var rule = {
+        action: 'exclude',
+        files: ['hello.txt', {}, 203]
+      };
+      transformer.exclude(rule, function (err) {
+        if (err) { return done(err); }
+        expect(transformer.addWarning.calledTwice).to.be.true();
+        expect(transformer.addWarning.calledWith(
+          'Non-string exclude filename encountered.'
+        )).to.be.true();
+        expect(transformer.addWarning.calledWith(
+          'Exclude files not specified as an array.'
+        )).to.be.false();
+        done();
+      });
+    });
+
+    it('should add file excludes', function(done) {
+      var rule = {
+        action: 'exclude',
+        files: ['A.txt', 'B.txt', 'C.txt']
+      };
+      var expectedFiles = rule.files.map(function (file) {
+        return transformer.driver.absolutePath(file);
+      });
+      transformer.exclude(rule, function (err) {
+        if (err) { return done(err); }
+        expect(transformer._globalExcludes).to.only.include(expectedFiles);
+        done();
+      });
+    });
+
+    it('should only add files once to the set', function(done) {
+      var rule = {
+        action: 'exclude',
+        files: ['A.txt', 'A.txt',  'C.txt', 'B.txt', 'C.txt']
+      };
+      transformer.exclude(rule, function (err) {
+        if (err) { return done(err); }
+        expect(transformer._globalExcludes.length).to.equal(3);
+        expect(transformer._globalExcludes).to.only.include([
+          '/etc/A.txt', '/etc/C.txt', '/etc/B.txt'
+        ]);
+        done();
+      });
+    });
+  }); // end 'exclude'
+}); // end 'Transformer'

--- a/test/transformer/exclude.js
+++ b/test/transformer/exclude.js
@@ -15,7 +15,7 @@ describe('Transformer', function() {
 
     beforeEach(function (done) {
       transformer = new Transformer('/etc', []);
-      sinon.stub(transformer, 'addWarning');
+      sinon.spy(transformer, 'addWarning');
       done();
     });
 

--- a/test/transformer/execution.js
+++ b/test/transformer/execution.js
@@ -212,6 +212,18 @@ describe('Transformer', function() {
       });
     });
 
+    it('should call the `exclude` handler given an "exclude" rule action', function(done) {
+      var rule = { action: 'exclude' };
+      var stub = sinon.stub(transformer._ruleActions, 'exclude').yields();
+      transformer.applyRule(rule, function (err) {
+        if (err) { return done(err); }
+        expect(stub.calledOnce).to.be.true();
+        expect(stub.calledWith(rule)).to.be.true();
+        transformer._ruleActions.exclude.restore();
+        done();
+      });
+    });
+
     it('should call a custom handler when given a custom rule action', function (done) {
       var rule = { action: 'custom' };
       var spy = sinon.stub(transformer._ruleActions, 'custom').yields();

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -159,6 +159,34 @@ describe('Transformer', function() {
       });
     });
 
+    it('should apply global file excludes', function(done) {
+      var rule = { search: 'koopa', replace: 'mario' };
+      transformer.exclude({ files: ['file2.txt', 'file4.txt'] }, noop);
+
+      var sed = sinon.stub(transformer.driver, 'sed').yields();
+      sinon.stub(transformer.driver, 'copy').yields();
+      sinon.stub(transformer.driver, 'remove').yields();
+      sinon.stub(transformer.driver, 'diff').yields();
+      sinon.stub(transformer.driver, 'grep').yields(null, [
+        '/etc/file1.txt:23:---',
+        '/etc/file2.txt:78:---',
+        '/etc/file3.txt:182:---',
+        '/etc/file4.txt:3232:---',
+        '/etc/suhweet/file4.txt:7:---'
+      ].join('\n'));
+
+      transformer.replace(rule, function (err) {
+        expect(sed.callCount).to.equal(3);
+        expect(sed.calledWith('koopa', 'mario', '/etc/file1.txt', 23))
+          .to.be.true();
+        expect(sed.calledWith('koopa', 'mario', '/etc/file3.txt', 182))
+          .to.be.true();
+        expect(sed.calledWith('koopa', 'mario', '/etc/suhweet/file4.txt', 7))
+          .to.be.true();
+        done();
+      });
+    });
+
     it('should appropriately apply exclude filters', function(done) {
       var rule = {
         search: 'a',


### PR DESCRIPTION
Adds a new rule type called `exclude` that will cause any subsequent `replace` rules to ignore a set of files. Here's an example rule set:

```json
[
  { "action": "exclude", "files": ["A.txt", "C.txt"] },
  { "action": "replace", "search": "foo", "replace": "bar" }
  { "action": "replace", "search": "food", "replace": "drink" }
]
```

The first rule will tell fs-transform that the files `A.txt` and `B.txt` should be excluded from subsequent replaces. Thus, the next two rules will ignore those files, even if they contain the search terms.
