### PR TITLE
Robust Scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
+sudo: false

--- a/README.md
+++ b/README.md
@@ -40,20 +40,11 @@ var rules = [
     search: 'foo',
     replace: 'bar',
 
-    // Use `exclude` property to define a set of files / lines to exclude
-    // from the global replace.
+    // Use `exclude` property to define a set of files to exclude for this
+    // search and replace
     exclude: [
-      {
-        name: 'another/file',
-        line: 22
-      },
-      {
-        name: 'complex/file',
-        lines: [12, 17, 94]
-      },
-      {
-        name: 'a/dir/'
-      }
+      'another/file',
+      'a/dir/'
     ]
   }
 ];

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ warnings. The warnings, in order of precedence, are:
 * `'All results were excluded.'` - The given set of excludes ended up removing
   all of the files from the search results.
 
-
 ## Dry Runs
 `fs-transform` performs all of its work in a temporary directory so it can
 gracefully fail if an error occurs (leaving the root directory as it was before
@@ -173,39 +172,8 @@ successfully, the `Transform` class will keep track of that command and which
 rule generated it (via the `.saveCommand` method).
 
 Once the transformation is complete, you can call the `.getScript` method to
-get all the commands as an executable shell script. Here's an example:
-
-```js
-var rules = [
-  { action: 'copy', source: 'foo', dest: 'bar' },
-  { action: 'replace', search: 'Socrates', replace: 'Plato' }
-]
-Transformer.transform('/tmp', rules, function (err, transformer) {
-  // Get the shell script:
-  var script = transformer.getScript();
-});
-```
-
-The script would look something like this:
-```sh
-#!/bin/sh
-
-#
-# Warning: this is a generated file, modifications may be overwritten.
-#
-
-# from rule: {action:"copy",source:"foo",dest:"bar"}
-cp /tmp/foo /tmp/bar
-
-# from rule: {action:"replace",search:"Socrates",replace:"Plato"}
-sed -i "" "13s/Socrates/Plato/g" /tmp/bar
-
-# from rule: {action:"replace",search:"Socrates",replace:"Plato"}
-sed -i "" "93s/Socrates/Plato/g" /tmp/bar
-
-# from rule: {action:"replace",search:"Socrates",replace:"Plato"}
-sed -i "" "4761s/Socrates/Plato/g" /tmp/bar
-```
+get all the commands as an executable shell script. For an example of the output
+script see [the test script](https://github.com/Runnable/fs-transform/blob/master/test/fixtures/script.sh).
 
 ## Generating Diffs
 `fs-transform` allows you to get a full recursive diff between the root

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -43,6 +43,18 @@ function FsDriver(root) {
 }
 
 /**
+ * Escapes a string for use in a command.
+ * @param {string} str String to escape.
+ * @return {string} The command line escaped string.
+ */
+FsDriver.escape = function (str) {
+  // Note: I tried alternatives to this, but none worked
+  // in both osx and linux :(
+  return str.replace(/(['/\\])/g, '\\$1');
+};
+
+
+/**
  * Commands required to use the `FsDriver` class.
  * @type {array}
  */
@@ -77,17 +89,6 @@ FsDriver.prototype.absolutePath = function (path) {
   return !this.working ?
     this.root + '/' + path :
     this.working + '/' + path;
-};
-
-/**
- * Escapes a string for use in a command.
- * @param {string} str String to escape.
- * @return {string} The command line escaped string.
- */
-FsDriver.prototype.escape = function (str) {
-  // Note: I tried alternatives to this, but none worked
-  // in both osx and linux :(
-  return str.replace(/(['/\\])/g, '\\$1');
 };
 
 /**
@@ -205,7 +206,7 @@ FsDriver.prototype.copy = function (source, dest, cb) {
 FsDriver.prototype.grep = function (text, cb) {
   this.exec([
     'grep -rn',
-    '\'' + this.escape(text) + '\'',
+    '\'' + FsDriver.escape(text) + '\'',
     this.working ? this.working : this.root
   ].join(' '), cb);
 };
@@ -229,8 +230,8 @@ FsDriver.prototype.grep = function (text, cb) {
 FsDriver.prototype.sed = function (search, replace, name, line, cb) {
   var pattern = [
     line + 's',
-    this.escape(search),
-    this.escape(replace),
+    FsDriver.escape(search),
+    FsDriver.escape(replace),
     'g'
   ].join('/');
 
@@ -352,14 +353,3 @@ FsDriver.prototype.removeWorkingDirectory = function (cb) {
 FsDriver.prototype.workingDiff = function (cb) {
   this.diff(this.root, this.working, cb);
 };
-
-/**
- * Exposes the escape method.
- */
-Object.defineProperty(FsDriver, 'escape', {
-  value: function (string) {
-    return new FsDriver('/').escape(string);
-  },
-  writable: false,
-  enumerable: true
-});

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -143,25 +143,6 @@ FsDriver.prototype.hasAllCommands = function(cb) {
 };
 
 /**
- * @returns a shell script that checks for all needed commands.
- */
-FsDriver.prototype.getCommandCheckScript = function () {
-  var checks = FsDriver.commands.map(function (name) {
-    return 'command -v ' + name + ' >/dev/null 2>&1 ' +
-      '|| { echo "' +
-      'Required command: ' + name +
-      ' -- Please install it before running this script.' +
-      '"; exit 1; }';
-  }).join('\n');
-
-  return [
-    '# Check to ensure required commands are available',
-    checks,
-    '# END Required command check'
-  ].join('\n') + '\n';
-};
-
-/**
  * Moves a file.
  *
  * @example
@@ -371,3 +352,14 @@ FsDriver.prototype.removeWorkingDirectory = function (cb) {
 FsDriver.prototype.workingDiff = function (cb) {
   this.diff(this.root, this.working, cb);
 };
+
+/**
+ * Exposes the escape method.
+ */
+Object.defineProperty(FsDriver, 'escape', {
+  value: function (string) {
+    return new FsDriver('/').escape(string);
+  },
+  writable: false,
+  enumerable: true
+});

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -61,8 +61,8 @@ ScriptGenerator.prototype.preamble = function () {
   var common = [
     '_script_name=`basename $0`',
     'search_files=\'.\'',
-    'warning() { echo "($_script_name) \\e[1;93mWARNING\\e[0m " $1; }',
-    'error() { echo "($_script_name) \\e[1;91mERROR\\e[0m " $1; exit 1; }\n'
+    'warning() { echo "($_script_name) WARNING" $1; }',
+    'error() { echo "($_script_name) ERROR" $1; exit 1; }\n'
   ].join('\n');
 
   var commandChecks = [
@@ -160,15 +160,17 @@ ScriptGenerator.prototype.replace = function (rule, index) {
   var replace = FsDriver.escape(rule.replace);
 
   var body = [
-    'results=$(grep -rL \'' + search + '\' $search_files)',
+    'results=($(grep -rl \'' + search + '\' $search_files))',
     'excludes="' + excludes + '"',
-    'if $results; then',
-    '  for name in $results do',
+    'if ((${#results[@]} > 0)); then',
+    '  for name in $results',
+    '  do',
     '    if [[ ! $excludes =~ $name ]]; then',
     '      sed -i.last \'s/' + search + '/' + replace + '/g\' $name || {',
     '        warning "Rule ' + index + ': could not replace ' +
                '\'' + search + '\' with \'' + replace + '\' in $name"',
     '      }',
+    '      rm -f $name.last',
     '    fi',
     '  done',
     'else',

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -154,6 +154,9 @@ ScriptGenerator.prototype.replace = function (rule, index) {
     header += ',\n' + '#   excludes: [' + rule.excludes.join(', ') + ']\n';
     excludes = rule.excludes.join(' ');
   }
+  else {
+    header += '\n';
+  }
   header += '# }\n';
 
   var search = FsDriver.escape(rule.search);

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -1,0 +1,204 @@
+'use strict';
+
+var FsDriver = require('./fs-driver');
+
+/**
+ * Generates shell scripts from transformation rules.
+ * @module fs-transform:script
+ * @author Ryan Sandor Richards
+ */
+module.exports = ScriptGenerator;
+
+/**
+ * Creates a new ScriptGenerator class that can generate scripts for the given
+ * set of transformation rules. Note: rules are not validated before generating
+ * the script. Please ensure you validate all rules using `Transformer.dry`
+ * before generating shell scripts.
+ * @class
+ * @param {array} rules Rules to convert into a shell script.
+ */
+function ScriptGenerator(rules) {
+  this.setRules(rules);
+  this.actionHandlers = {
+    'copy': this.copy.bind(this),
+    'rename': this.rename.bind(this),
+    'replace': this.replace.bind(this),
+    'exclude': this.exclude.bind(this)
+  };
+}
+
+/**
+ * Sets the rules for the script generator.
+ * @param {array} rules Rules to set for the generator.
+ */
+ScriptGenerator.prototype.setRules = function (rules) {
+  this.rules = rules;
+};
+
+/**
+ * Generates a shell script from the rules.
+ * @return {string} A shell script generated from the provided rules.
+ */
+ScriptGenerator.prototype.generate = function() {
+  return [
+    this.preamble(),
+    this.rules.map(this.generateRule.bind(this)).join('\n')
+  ].join('\n');
+};
+
+/**
+ * Generates the preamble for the shell script.
+ * @return {string} The preamble for the script.
+ */
+ScriptGenerator.prototype.preamble = function () {
+  var header = [
+    '#!/bin/sh\n',
+    '#',
+    '# Warning: this is a generated file, modifications may be overwritten.',
+    '#\n'
+  ].join('\n');
+
+  var common = [
+    '_script_name=`basename $0`',
+    'search_files=\'.\'',
+    'warning() { echo "($_script_name) \\e[1;93mWARNING\\e[0m " $1; }',
+    'error() { echo "($_script_name) \\e[1;91mERROR\\e[0m " $1; exit 1; }\n'
+  ].join('\n');
+
+  var commandChecks = [
+    FsDriver.commands.map(function (name) {
+      return 'command -v ' + name + ' >/dev/null 2>&1 || {\n' +
+        '  error "Missing required command: ' + name + '";\n' +
+        '}';
+    }).join('\n'),
+  ].join('\n') + '\n';
+
+  return [header, common, commandChecks].join('\n');
+};
+
+/**
+ * Generates the script for the given rule.
+ * @param {object} rule Rule for which to generate the script.
+ * @return {string} The script that handles the given rule.
+ */
+ScriptGenerator.prototype.generateRule = function (rule, index) {
+  return this.actionHandlers[rule.action](rule, index);
+};
+
+/**
+ * Generates the script for a copy rule.
+ * @param {object} rule Copy rule.
+ * @return {string} Script for the given rule.
+ */
+ScriptGenerator.prototype.copy = function (rule, index) {
+  var header = [
+    '# RULE ' + index,
+    '# {',
+    '#   action: "' + rule.action + '",',
+    '#   source: "' + rule.source + '",',
+    '#   dest: "' + rule.dest + '"',
+    '# }'
+  ].join('\n') + '\n';
+
+  var body = [
+    'cp ' + rule.source + ' ' + rule.dest + ' || {',
+    '  warning "Rule ' + index + ': unable to copy ' +
+      rule.source + ' to ' + rule.dest + '"',
+    '}'
+  ].join('\n');
+
+  return [header, body].join('\n') + '\n';
+};
+
+/**
+ * Generates the script for a rename rule.
+ * @param {object} rule Rename rule.
+ * @return {string} Script for the given rule.
+ */
+ScriptGenerator.prototype.rename = function (rule, index) {
+  var header = [
+    '# RULE ' + index,
+    '# {',
+    '#   action: "' + rule.action + '",',
+    '#   source: "' + rule.source + '",',
+    '#   dest: "' + rule.dest + '"',
+    '# }'
+  ].join('\n') + '\n';
+
+  var body = [
+    'mv ' + rule.source + ' ' + rule.dest + ' || {',
+    '  warning "Rule ' + index + ': unable to rename ' +
+      rule.source + ' to ' + rule.dest + '"',
+    '}'
+  ].join('\n');
+
+  return [header, body].join('\n') + '\n';
+};
+
+/**
+ * Generates the script for a replace rule.
+ * @param {object} rule Replace rule.
+ * @return {string} Script for the given rule.
+ */
+ScriptGenerator.prototype.replace = function (rule, index) {
+  var header = [
+    '# RULE ' + index,
+    '# {',
+    '#   action: ' + rule.action + ',',
+    '#   search: "' + rule.search + '",',
+    '#   replace: "' + rule.replace + '"'
+  ].join('\n');
+
+  var excludes = "";
+  if (rule.excludes) {
+    header += ',\n' + '#   excludes: [' + rule.excludes.join(', ') + ']\n';
+    excludes = rule.excludes.join(' ');
+  }
+  header += '# }\n';
+
+  var search = FsDriver.escape(rule.search);
+  var replace = FsDriver.escape(rule.replace);
+
+  var body = [
+    'results=$(grep -rL \'' + search + '\' $search_files)',
+    'excludes="' + excludes + '"',
+    'if $results; then',
+    '  for name in $results do',
+    '    if [[ ! $excludes =~ $name ]]; then',
+    '      sed -i.last \'s/' + search + '/' + replace + '/g\' $name || {',
+    '        warning "Rule ' + index + ': could not replace ' +
+               '\'' + search + '\' with \'' + replace + '\' in $name"',
+    '      }',
+    '    fi',
+    '  done',
+    'else',
+    '  warning "Rule ' + index + ': no search results to replace."',
+    'fi'
+  ].join('\n');
+
+  return [header, body].join('\n') + '\n';
+};
+
+/**
+ * Generates the script for a exclude rule.
+ * @param {object} rule Exclude rule.
+ * @return {string} Script for the given rule.
+ */
+ScriptGenerator.prototype.exclude = function (rule, index) {
+  var header = [
+    '# RULE ' + index,
+    '# {',
+    '#   action: "' + rule.action + '",',
+    '#   files: [' + rule.files.join(', ') + ']',
+    '# }'
+  ].join('\n');
+
+  var excludes = rule.files.map(function (name) {
+    return '\\( ! -name \'' + name + '\' \\)';
+  }).join(' ');
+
+  return [
+    header,
+    'search_files=`find . -type f ' + excludes +  '`\n'
+  ].join('\n');
+};

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -79,6 +79,8 @@ ScriptGenerator.prototype.preamble = function () {
 /**
  * Generates the script for the given rule.
  * @param {object} rule Rule for which to generate the script.
+ * @param {Number} [index] Optional index position for the rule in a greater
+ *   rule set.
  * @return {string} The script that handles the given rule.
  */
 ScriptGenerator.prototype.generateRule = function (rule, index) {
@@ -107,7 +109,7 @@ ScriptGenerator.prototype.copy = function (rule, index) {
     '}'
   ].join('\n');
 
-  return [header, body].join('\n') + '\n';
+  return [header, body, ''].join('\n');
 };
 
 /**
@@ -132,7 +134,7 @@ ScriptGenerator.prototype.rename = function (rule, index) {
     '}'
   ].join('\n');
 
-  return [header, body].join('\n') + '\n';
+  return [header, body, ''].join('\n');
 };
 
 /**
@@ -181,7 +183,7 @@ ScriptGenerator.prototype.replace = function (rule, index) {
     'fi'
   ].join('\n');
 
-  return [header, body].join('\n') + '\n';
+  return [header, body, ''].join('\n');
 };
 
 /**
@@ -204,6 +206,7 @@ ScriptGenerator.prototype.exclude = function (rule, index) {
 
   return [
     header,
-    'search_files=`find . -type f ' + excludes +  '`\n'
+    'search_files=`find . -type f ' + excludes +  '`',
+    ''
   ].join('\n');
 };

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -52,7 +52,7 @@ ScriptGenerator.prototype.generate = function() {
  */
 ScriptGenerator.prototype.preamble = function () {
   var header = [
-    '#!/bin/sh\n',
+    '#!/bin/bash\n',
     '#',
     '# Warning: this is a generated file, modifications may be overwritten.',
     '#\n'

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -423,27 +423,14 @@ Transformer.prototype.replace = function (rule, cb) {
       ruleApplied[index] = false;
     });
 
-    // 2.2 Determine which files to keep
+    // 2.2 Handle local rule file excludes
     files = files.filter(function (file) {
       var keepFile = true;
-
-      exclude.forEach(function(excludeRule, index) {
-        var name = self.driver.absolutePath(excludeRule.name);
-        var line = excludeRule.line;
-
-        if (exists(name) && exists(line)) {
-          if (name === file.name && parseInt(line) === parseInt(file.line)) {
-            keepFile = false;
-            ruleApplied[index] = true;
-            return;
-          }
-        }
-        else if (exists(name)) {
-          if (name === file.name) {
-            ruleApplied[index] = true;
-            keepFile = false;
-            return;
-          }
+      exclude.forEach(function(name, index) {
+        if (self.driver.absolutePath(name) === file.name) {
+          keepFile = false;
+          ruleApplied[index] = true;
+          return;
         }
       });
       return keepFile;

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -4,6 +4,7 @@ var async = require('async');
 var isString = require('101/is-string');
 var FsDriver = require('./fs-driver');
 var Warning = require('./warning');
+var ScriptGenerator = require('./script-generator');
 var exists = require('101/exists');
 var debug = require('debug');
 var fullDiffDebug = debug('fs-transform:full-diff');
@@ -39,9 +40,9 @@ function Transformer(root, rules) {
   this._ruleActions = {};
   this.currentResult = null;
   this.warnings = [];
-  this.commands = [];
   this.results = [];
   this.nameChanges = [];
+  this.scriptGenerator = new ScriptGenerator(rules);
 
   this.setAction('copy', this.copy);
   this.setAction('rename', this.rename);
@@ -63,7 +64,6 @@ Transformer.ORIGINAL_POSTFIX = '.fs-transform.original';
 Transformer.prototype.pushResult = function (rule) {
   this.currentResult = {
     rule: rule,
-    commands: [],
     warnings: [],
     nameChanges: [],
     diffs: {}
@@ -114,41 +114,11 @@ Transformer.prototype.addDiff = function (filename, diff) {
 };
 
 /**
- * Saves a command that was executed by the transformer. We do this so we can
- * reconstruct all of the transformations in the form of a script.
- * @param {string} command Command to save.
- * @param {object} rule Rule that generated the command.
- */
-Transformer.prototype.saveCommand = function (command, rule) {
-  this.commands.push({
-    rule: rule,
-    command: command
-  });
-  if (exists(this.currentResult)) {
-    this.currentResult.commands.push(command);
-  }
-};
-
-/**
- * @return the commands executed by this transformer in the form of a command
- *   line script.
+ * Generates a shell script from this transfromer's rules.
+ * @return {string} A shell-script that executes the rules.
  */
 Transformer.prototype.getScript = function () {
-  var preamble = [
-    '#!/bin/sh\n',
-    '#',
-    '# Warning: this is a generated file, modifications may be overwritten.',
-    '#\n'
-  ].join('\n');
-
-  var commandCheck = this.driver.getCommandCheckScript();
-
-  var commands = this.commands.map(function (cmd) {
-    return ('# from rule: ' + JSON.stringify(cmd.rule)) + '\n' +
-      cmd.command;
-  }).join('\n\n');
-
-  return [preamble, commandCheck, commands, ''].join('\n');
+  return this.scriptGenerator.generate();
 };
 
 /**
@@ -259,7 +229,6 @@ Transformer.prototype.dry = function (cb) {
  */
 Transformer.prototype._execute = function (commit, executeCallback) {
   var self = this;
-  this.commands = [];
   this._fullDiff = "";
 
   async.series([
@@ -377,9 +346,8 @@ Transformer.prototype.copy = function (rule, cb) {
     return cb();
   }
   var self = this;
-  this.driver.copy(rule.source, rule.dest, function (err, output, command) {
+  this.driver.copy(rule.source, rule.dest, function (err, output) {
     if (err) { return cb(err); }
-    self.saveCommand(command, rule);
     self.addNameChange(rule.source, rule.dest);
     cb();
   });
@@ -395,9 +363,8 @@ Transformer.prototype.rename = function (rule, cb) {
     return cb();
   }
   var self = this;
-  this.driver.move(rule.source, rule.dest, function (err, output, command) {
+  this.driver.move(rule.source, rule.dest, function (err, output) {
     if (err) { return cb(err); }
-    self.saveCommand(command, rule);
     self.addNameChange(rule.source, rule.dest);
     cb();
   });
@@ -522,11 +489,7 @@ Transformer.prototype.replace = function (rule, cb) {
             replace,
             file.name,
             parseInt(file.line),
-            function(err, output, command) {
-              if (err) { return sedCallback(err); }
-              self.saveCommand(command, rule);
-              sedCallback();
-            }
+            sedCallback
           );
         }, cb);
       },

--- a/test/fixtures/copy.sh
+++ b/test/fixtures/copy.sh
@@ -1,0 +1,10 @@
+# RULE 102
+# {
+#   action: "copy",
+#   source: "foo.txt",
+#   dest: "bar.rtf"
+# }
+
+cp foo.txt bar.rtf || {
+  warning "Rule 102: unable to copy foo.txt to bar.rtf"
+}

--- a/test/fixtures/exclude.sh
+++ b/test/fixtures/exclude.sh
@@ -1,0 +1,6 @@
+# RULE 1234
+# {
+#   action: "exclude",
+#   files: [A.dmg, B.tar.gz, gamma.pajama]
+# }
+search_files=`find . -type f \( ! -name 'A.dmg' \) \( ! -name 'B.tar.gz' \) \( ! -name 'gamma.pajama' \)`

--- a/test/fixtures/rename.sh
+++ b/test/fixtures/rename.sh
@@ -1,0 +1,10 @@
+# RULE 42
+# {
+#   action: "rename",
+#   source: "foo.txt",
+#   dest: "bar.rtf"
+# }
+
+mv foo.txt bar.rtf || {
+  warning "Rule 42: unable to rename foo.txt to bar.rtf"
+}

--- a/test/fixtures/replace-no-exclude.sh
+++ b/test/fixtures/replace-no-exclude.sh
@@ -1,0 +1,19 @@
+# RULE 9000
+# {
+#   action: replace,
+#   search: "absolutely",
+#   replace: "probably"# }
+
+results=$(grep -rL 'absolutely' $search_files)
+excludes=""
+if $results; then
+  for name in $results do
+    if [[ ! $excludes =~ $name ]]; then
+      sed -i.last 's/absolutely/probably/g' $name || {
+        warning "Rule 9000: could not replace 'absolutely' with 'probably' in $name"
+      }
+    fi
+  done
+else
+  warning "Rule 9000: no search results to replace."
+fi

--- a/test/fixtures/replace-no-exclude.sh
+++ b/test/fixtures/replace-no-exclude.sh
@@ -4,14 +4,16 @@
 #   search: "absolutely",
 #   replace: "probably"# }
 
-results=$(grep -rL 'absolutely' $search_files)
+results=($(grep -rl 'absolutely' $search_files))
 excludes=""
-if $results; then
-  for name in $results do
+if ((${#results[@]} > 0)); then
+  for name in $results
+  do
     if [[ ! $excludes =~ $name ]]; then
       sed -i.last 's/absolutely/probably/g' $name || {
         warning "Rule 9000: could not replace 'absolutely' with 'probably' in $name"
       }
+      rm -f $name.last
     fi
   done
 else

--- a/test/fixtures/replace-no-exclude.sh
+++ b/test/fixtures/replace-no-exclude.sh
@@ -2,7 +2,8 @@
 # {
 #   action: replace,
 #   search: "absolutely",
-#   replace: "probably"# }
+#   replace: "probably"
+# }
 
 results=($(grep -rl 'absolutely' $search_files))
 excludes=""

--- a/test/fixtures/replace.sh
+++ b/test/fixtures/replace.sh
@@ -1,0 +1,21 @@
+# RULE 55
+# {
+#   action: replace,
+#   search: "whut",
+#   replace: "wat",
+#   excludes: [A.dmg, B.tar.gz]
+# }
+
+results=$(grep -rL 'whut' $search_files)
+excludes="A.dmg B.tar.gz"
+if $results; then
+  for name in $results do
+    if [[ ! $excludes =~ $name ]]; then
+      sed -i.last 's/whut/wat/g' $name || {
+        warning "Rule 55: could not replace 'whut' with 'wat' in $name"
+      }
+    fi
+  done
+else
+  warning "Rule 55: no search results to replace."
+fi

--- a/test/fixtures/replace.sh
+++ b/test/fixtures/replace.sh
@@ -6,14 +6,16 @@
 #   excludes: [A.dmg, B.tar.gz]
 # }
 
-results=$(grep -rL 'whut' $search_files)
+results=($(grep -rl 'whut' $search_files))
 excludes="A.dmg B.tar.gz"
-if $results; then
-  for name in $results do
+if ((${#results[@]} > 0)); then
+  for name in $results
+  do
     if [[ ! $excludes =~ $name ]]; then
       sed -i.last 's/whut/wat/g' $name || {
         warning "Rule 55: could not replace 'whut' with 'wat' in $name"
       }
+      rm -f $name.last
     fi
   done
 else

--- a/test/fixtures/script-preamble.sh
+++ b/test/fixtures/script-preamble.sh
@@ -6,8 +6,8 @@
 
 _script_name=`basename $0`
 search_files='.'
-warning() { echo "($_script_name) \e[1;93mWARNING\e[0m " $1; }
-error() { echo "($_script_name) \e[1;91mERROR\e[0m " $1; exit 1; }
+warning() { echo "($_script_name) WARNING" $1; }
+error() { echo "($_script_name) ERROR" $1; exit 1; }
 
 command -v cp >/dev/null 2>&1 || {
   error "Missing required command: cp";

--- a/test/fixtures/script-preamble.sh
+++ b/test/fixtures/script-preamble.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+#
+# Warning: this is a generated file, modifications may be overwritten.
+#
+
+_script_name=`basename $0`
+search_files='.'
+warning() { echo "($_script_name) \e[1;93mWARNING\e[0m " $1; }
+error() { echo "($_script_name) \e[1;91mERROR\e[0m " $1; exit 1; }
+
+command -v cp >/dev/null 2>&1 || {
+  error "Missing required command: cp";
+}
+command -v mv >/dev/null 2>&1 || {
+  error "Missing required command: mv";
+}
+command -v grep >/dev/null 2>&1 || {
+  error "Missing required command: grep";
+}
+command -v sed >/dev/null 2>&1 || {
+  error "Missing required command: sed";
+}
+command -v diff >/dev/null 2>&1 || {
+  error "Missing required command: diff";
+}
+command -v rm >/dev/null 2>&1 || {
+  error "Missing required command: rm";
+}

--- a/test/fixtures/script-preamble.sh
+++ b/test/fixtures/script-preamble.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Warning: this is a generated file, modifications may be overwritten.

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -32,7 +32,8 @@ command -v rm >/dev/null 2>&1 || {
 # {
 #   action: replace,
 #   search: "\sum",
-#   replace: "\prod"# }
+#   replace: "\prod"
+# }
 
 results=($(grep -rl '\\sum' $search_files))
 excludes=""

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -6,8 +6,8 @@
 
 _script_name=`basename $0`
 search_files='.'
-warning() { echo "($_script_name) \e[1;93mWARNING\e[0m " $1; }
-error() { echo "($_script_name) \e[1;91mERROR\e[0m " $1; exit 1; }
+warning() { echo "($_script_name) WARNING" $1; }
+error() { echo "($_script_name) ERROR" $1; exit 1; }
 
 command -v cp >/dev/null 2>&1 || {
   error "Missing required command: cp";
@@ -34,14 +34,16 @@ command -v rm >/dev/null 2>&1 || {
 #   search: "\sum",
 #   replace: "\prod"# }
 
-results=$(grep -rL '\\sum' $search_files)
+results=($(grep -rl '\\sum' $search_files))
 excludes=""
-if $results; then
-  for name in $results do
+if ((${#results[@]} > 0)); then
+  for name in $results
+  do
     if [[ ! $excludes =~ $name ]]; then
       sed -i.last 's/\\sum/\\prod/g' $name || {
         warning "Rule 0: could not replace '\\sum' with '\\prod' in $name"
       }
+      rm -f $name.last
     fi
   done
 else

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -4,23 +4,79 @@
 # Warning: this is a generated file, modifications may be overwritten.
 #
 
-# Check to ensure required commands are available
-command -v cp >/dev/null 2>&1 || { echo "Required command: cp -- Please install it before running this script."; exit 1; }
-command -v mv >/dev/null 2>&1 || { echo "Required command: mv -- Please install it before running this script."; exit 1; }
-command -v grep >/dev/null 2>&1 || { echo "Required command: grep -- Please install it before running this script."; exit 1; }
-command -v sed >/dev/null 2>&1 || { echo "Required command: sed -- Please install it before running this script."; exit 1; }
-command -v diff >/dev/null 2>&1 || { echo "Required command: diff -- Please install it before running this script."; exit 1; }
-command -v rm >/dev/null 2>&1 || { echo "Required command: rm -- Please install it before running this script."; exit 1; }
-# END Required command check
+_script_name=`basename $0`
+search_files='.'
+warning() { echo "($_script_name) \e[1;93mWARNING\e[0m " $1; }
+error() { echo "($_script_name) \e[1;91mERROR\e[0m " $1; exit 1; }
 
-# from rule: {"action":"replace","search":"\\sum","replace":"\\prod"}
-sed -i.last '2s/\\sum/\\prod/g' $ROOT/sub/C
+command -v cp >/dev/null 2>&1 || {
+  error "Missing required command: cp";
+}
+command -v mv >/dev/null 2>&1 || {
+  error "Missing required command: mv";
+}
+command -v grep >/dev/null 2>&1 || {
+  error "Missing required command: grep";
+}
+command -v sed >/dev/null 2>&1 || {
+  error "Missing required command: sed";
+}
+command -v diff >/dev/null 2>&1 || {
+  error "Missing required command: diff";
+}
+command -v rm >/dev/null 2>&1 || {
+  error "Missing required command: rm";
+}
 
-# from rule: {"action":"copy","source":"A","dest":"A-copy"}
-cp $ROOT/A $ROOT/A-copy
+# RULE 0
+# {
+#   action: replace,
+#   search: "\sum",
+#   replace: "\prod"# }
 
-# from rule: {"action":"copy","source":"B","dest":"B-copy"}
-cp $ROOT/B $ROOT/B-copy
+results=$(grep -rL '\\sum' $search_files)
+excludes=""
+if $results; then
+  for name in $results do
+    if [[ ! $excludes =~ $name ]]; then
+      sed -i.last 's/\\sum/\\prod/g' $name || {
+        warning "Rule 0: could not replace '\\sum' with '\\prod' in $name"
+      }
+    fi
+  done
+else
+  warning "Rule 0: no search results to replace."
+fi
 
-# from rule: {"action":"rename","source":"sub/C","dest":"sub/C-rename"}
-mv $ROOT/sub/C $ROOT/sub/C-rename
+# RULE 1
+# {
+#   action: "copy",
+#   source: "A",
+#   dest: "A-copy"
+# }
+
+cp A A-copy || {
+  warning "Rule 1: unable to copy A to A-copy"
+}
+
+# RULE 2
+# {
+#   action: "copy",
+#   source: "B",
+#   dest: "B-copy"
+# }
+
+cp B B-copy || {
+  warning "Rule 2: unable to copy B to B-copy"
+}
+
+# RULE 3
+# {
+#   action: "rename",
+#   source: "sub/C",
+#   dest: "sub/C-rename"
+# }
+
+mv sub/C sub/C-rename || {
+  warning "Rule 3: unable to rename sub/C to sub/C-rename"
+}

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #
 # Warning: this is a generated file, modifications may be overwritten.

--- a/test/functional.js
+++ b/test/functional.js
@@ -247,7 +247,7 @@ describe('functional', function () {
         },
 
         function runScript(next) {
-          var command = 'sh ../script.sh';
+          var command = 'bash ../script.sh';
           childProcess.exec(command, {cwd: scriptPath}, function (err, data) {
             next(err);
           });

--- a/test/functional.js
+++ b/test/functional.js
@@ -155,9 +155,8 @@ describe('functional', function () {
         search: 'Mew',
         replace: 'Woof',
         exclude: [
-          { name: 'B' },
-          { name: 'sub/C', line: 8 },
-          { name: 'not-there' }
+          'B',
+          'not-there'
         ]
       }];
       Transformer.transform(fs.path, rules, function (err, transformer) {
@@ -167,7 +166,7 @@ describe('functional', function () {
         expect(linesC[3]).to.equal('Woof');
         expect(linesC[4]).to.equal('Woof');
         expect(linesC[5]).to.equal('Woof');
-        expect(linesC[7]).to.equal('Mew');
+        expect(linesC[7]).to.equal('Woof');
         expect(dataB.match('Woof')).to.be.null();
         expect(transformer.warnings).to.not.be.empty();
         expect(transformer.warnings[0].message)
@@ -183,7 +182,7 @@ describe('functional', function () {
         action: 'replace',
         search: search,
         replace: replace,
-        exclude: [{ name: 'A' }]
+        exclude: ['A']
       }];
       Transformer.transform(fs.path, rules, function (err, transformer) {
         if (err) { return done(err); }

--- a/test/script-generator.js
+++ b/test/script-generator.js
@@ -1,0 +1,234 @@
+'use strict';
+
+var Lab = require('lab');
+var lab = exports.lab = Lab.script();
+var describe = lab.describe;
+var it = lab.it;
+var before = lab.before;
+var beforeEach = lab.beforeEach;
+var after = lab.after;
+var afterEach = lab.afterEach;
+var Code = require('code');
+var expect = Code.expect;
+var sinon = require('sinon');
+
+var ScriptGenerator = require('../lib/script-generator');
+var fs = require('fs');
+
+describe('ScriptGenerator', function() {
+  describe('constructor', function () {
+    it('should set the given rules', function(done) {
+      var rules = [1, 2, 3];
+      sinon.stub(ScriptGenerator.prototype, 'setRules');
+      var script = new ScriptGenerator(rules);
+      expect(ScriptGenerator.prototype.setRules.calledWith(rules)).to.be.true();
+      ScriptGenerator.prototype.setRules.restore();
+      done();
+    });
+
+    it('should set the action handlers', function(done) {
+      var script = new ScriptGenerator();
+      var handlerNames = ['copy', 'rename', 'replace', 'exclude'];
+      expect(script.actionHandlers).to.exist();
+      handlerNames.forEach(function (name) {
+        expect(script.actionHandlers[name]).to.exist();
+      });
+      done();
+    });
+  }); // end 'describe'
+
+  describe('setRules', function() {
+    it('should set the rules for the generator', function(done) {
+      var rules = [1, 2, 3];
+      var script = new ScriptGenerator(rules);
+      expect(script.rules).to.equal(rules);
+      done();
+    });
+  }); // end 'setRules'
+
+  describe('generate', function() {
+    var script;
+
+    beforeEach(function (done) {
+      script = new ScriptGenerator();
+      sinon.stub(script, 'preamble').returns('PREAMBLE');
+      sinon.stub(script, 'generateRule', function (rule) {
+        return "RULE " + rule;
+      });
+      done();
+    });
+
+    it('should generate the preamble', function(done) {
+      script.setRules([ 1, 2, 3 ]);
+      script.generate();
+      expect(script.preamble.calledOnce).to.be.true();
+      done();
+    });
+
+    it('should generate the rule scripts', function(done) {
+      script.setRules([4, 5, 6]);
+      script.generate();
+      expect(script.generateRule.callCount).to.equal(3);
+      expect(script.generateRule.calledWith(4)).to.be.true();
+      expect(script.generateRule.calledWith(5)).to.be.true();
+      expect(script.generateRule.calledWith(6)).to.be.true();
+      done();
+    });
+
+    it('should return the fully composed script', function(done) {
+      script.setRules(['A', 'B', 'C']);
+      var result = script.generate();
+      expect(result).to.equal(
+        'PREAMBLE\n' +
+        'RULE A\n' +
+        'RULE B\n' +
+        'RULE C'
+      );
+      done();
+    });
+  }); // end 'generate'
+
+  describe('preamble', function() {
+    it('should generate and return the preamble', function(done) {
+      expect(new ScriptGenerator().preamble()).to.equal(
+        fs.readFileSync('test/fixtures/script-preamble.sh').toString()
+      );
+      done();
+    });
+  }); // end 'preamble'
+
+  describe('generateRule', function() {
+    var script = new ScriptGenerator();
+
+    beforeEach(function (done) {
+      sinon.stub(script.actionHandlers, 'copy');
+      sinon.stub(script.actionHandlers, 'rename');
+      sinon.stub(script.actionHandlers, 'replace');
+      sinon.stub(script.actionHandlers, 'exclude');
+      done();
+    });
+
+    afterEach(function (done) {
+      script.actionHandlers.copy.restore();
+      script.actionHandlers.rename.restore();
+      script.actionHandlers.replace.restore();
+      script.actionHandlers.exclude.restore();
+      done();
+    });
+
+    it('should use the copy handler for copy rules', function(done) {
+      var rule = { action: 'copy' };
+      var index = 1;
+      script.generateRule(rule, index);
+      expect(script.actionHandlers.copy.calledWith(rule, index))
+        .to.be.true();
+      done();
+    });
+
+    it('should use the rename handler for rename rules', function(done) {
+      var rule = { action: 'rename' };
+      var index = 341;
+      script.generateRule(rule, index);
+      expect(script.actionHandlers.rename.calledWith(rule, index))
+        .to.be.true();
+      done();
+    });
+
+    it('should use the replace handler for replace rules', function(done) {
+      var rule = { action: 'replace' };
+      var index = 8888;
+      script.generateRule(rule, index);
+      expect(script.actionHandlers.replace.calledWith(rule, index))
+        .to.be.true();
+      done();
+    });
+
+    it('should use the exclude handler for exclude rules', function(done) {
+      var rule = { action: 'exclude' };
+      var index = 1337;
+      script.generateRule(rule, index);
+      expect(script.actionHandlers.exclude.calledWith(rule, index))
+        .to.be.true();
+      done();
+    });
+  }); // end 'generateRule'
+
+  describe('copy', function() {
+    it('should generate the script for a copy', function(done) {
+      var script = new ScriptGenerator();
+      var rule = {
+        action: 'copy',
+        source: 'foo.txt',
+        dest: 'bar.rtf'
+      };
+      var index = 102;
+      expect(script.copy(rule, index)).to.equal(
+        fs.readFileSync('test/fixtures/copy.sh').toString()
+      );
+      done();
+    });
+  }); // end 'copy'
+
+  describe('rename', function() {
+    it('should generate the script for a rename', function(done) {
+      var script = new ScriptGenerator();
+      var rule = {
+        action: 'rename',
+        source: 'foo.txt',
+        dest: 'bar.rtf'
+      };
+      var index = 42;
+      expect(script.rename(rule, index)).to.equal(
+        fs.readFileSync('test/fixtures/rename.sh').toString()
+      );
+      done();
+    });
+  }); // end 'rename'
+
+  describe('replace', function() {
+    it('should generate the script for a replace', function(done) {
+      var script = new ScriptGenerator();
+      var rule = {
+        action: 'replace',
+        search: 'whut',
+        replace: 'wat',
+        excludes: ['A.dmg', 'B.tar.gz']
+      };
+      var index = 55;
+      expect(script.replace(rule, index)).to.equal(
+        fs.readFileSync('test/fixtures/replace.sh').toString()
+      );
+      done();
+    });
+
+    it('should generate a script for replace without local excludes', function(done) {
+      var script = new ScriptGenerator();
+      var rule = {
+        action: 'replace',
+        search: 'absolutely',
+        replace: 'probably'
+      };
+      var index = 9000;
+      expect(script.replace(rule, index)).to.equal(
+        fs.readFileSync('test/fixtures/replace-no-exclude.sh').toString()
+      );
+      done();
+    });
+  }); // end 'replace'
+
+  describe('exclude', function() {
+    it('should generate the script for a exclude', function(done) {
+      var script = new ScriptGenerator();
+      var rule = {
+        action: 'exclude',
+        files: ['A.dmg', 'B.tar.gz', 'gamma.pajama']
+      };
+      var index = 1234;
+      expect(script.exclude(rule, index)).to.equal(
+        fs.readFileSync('test/fixtures/exclude.sh').toString()
+      );
+      done();
+    });
+  }); // end 'exclude'
+
+}); // end 'shell-script'

--- a/test/transformer/constructor.js
+++ b/test/transformer/constructor.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var Lab = require('lab');
 var lab = exports.lab = Lab.script();
 var describe = lab.describe;
@@ -9,6 +11,7 @@ var afterEach = lab.afterEach;
 var Code = require('code');
 var expect = Code.expect;
 var Transformer = require('../../lib/transformer');
+var ScriptGenerator = require('../../lib/script-generator');
 
 describe('Transformer', function() {
   describe('constructor', function() {
@@ -51,9 +54,9 @@ describe('Transformer', function() {
       done();
     });
 
-    it('should keep a list of commands', function (done) {
+    it('should have a shell script generator', function(done) {
       var transformer = new Transformer('/etc', []);
-      expect(transformer.commands).to.be.an.array();
+      expect(transformer.scriptGenerator).instanceof(ScriptGenerator);
       done();
     });
 

--- a/test/transformer/copy.js
+++ b/test/transformer/copy.js
@@ -106,24 +106,18 @@ describe('Transformer', function() {
       });
     });
 
-    it('should save the copy command', function(done) {
-      var rule = { source: 'foo', dest: 'bar' };
-      var spy = sinon.spy(transformer, 'saveCommand');
-      sinon.stub(transformer.driver, 'exists').returns(true);
-      transformer.copy(rule, function () {
-        expect(spy.calledOnce).to.be.true();
-        transformer.driver.exists.restore();
-        done();
-      });
-    });
+    it('should handle driver copy errors', function(done) {
+      var error = new Error('FOOL! foOOl.. fool?');
+      transformer.driver.copy.yieldsAsync(error);
 
-    it('should not save the copy command if an error occurred', function (done) {
-      var rule = { source: 'foo', dest: 'bar' };
-      var spy = sinon.spy(transformer, 'saveCommand');
-      sinon.stub(transformer.driver, 'exists').returns(true);
-      transformer.driver.copy.yields(new Error('error'));
+      sinon.stub(transformer.driver, 'exists')
+        .withArgs('foo').returns(true)
+        .withArgs('bar').returns(false);
+
+      var rule = { action: 'copy', source: 'foo', dest: 'bar'};
       transformer.copy(rule, function (err) {
-        expect(spy.callCount).to.equal(0);
+        expect(err).to.equal(error);
+        transformer.driver.exists.restore();
         done();
       });
     });

--- a/test/transformer/rename.js
+++ b/test/transformer/rename.js
@@ -106,24 +106,18 @@ describe('Transformer', function() {
       });
     });
 
-    it('should save the move command', function(done) {
-      var rule = { source: 'foo', dest: 'bar' };
-      var spy = sinon.spy(transformer, 'saveCommand');
-      sinon.stub(transformer.driver, 'exists').returns(true);
-      transformer.rename(rule, function () {
-        expect(spy.calledOnce).to.be.true();
-        transformer.driver.exists.restore();
-        done();
-      });
-    });
+    it('should handle driver move errors', function(done) {
+      var error = new Error('Yes? no? maybe so... ugbndkslnbfdklsn');
+      transformer.driver.move.yieldsAsync(error);
 
-    it('should not save the copy command if an error occurred', function (done) {
-      var rule = { source: 'foo', dest: 'bar' };
-      var spy = sinon.spy(transformer, 'saveCommand');
-      sinon.stub(transformer.driver, 'exists').returns(true);
-      transformer.driver.move.yields(new Error('error'));
+      sinon.stub(transformer.driver, 'exists')
+        .withArgs('foo').returns(true)
+        .withArgs('bar').returns(false);
+
+      var rule = { action: 'rename', source: 'foo', dest: 'bar'};
       transformer.rename(rule, function (err) {
-        expect(spy.callCount).to.equal(0);
+        expect(err).to.equal(error);
+        transformer.driver.exists.restore();
         done();
       });
     });

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -254,61 +254,6 @@ describe('Transformer', function() {
       });
     });
 
-    it('should save each sed command', function(done) {
-      var rule = {
-        action: 'replace',
-        search: 'alpha',
-        replace: 'beta'
-      };
-      var command = 'sed -i "" "s/alpha/beta/" file.txt';
-      var saveCommand = sinon.spy(transformer, 'saveCommand');
-
-      sinon.stub(transformer.driver, 'sed')
-        .yieldsAsync(null, null, command);
-      sinon.stub(transformer.driver, 'copy').yields();
-      sinon.stub(transformer.driver, 'remove').yields();
-      sinon.stub(transformer.driver, 'diff').yields();
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt:10:---',
-        '/etc/file.txt:12:---',
-        '/etc/file.txt:14:---'
-      ].join('\n'));
-
-      transformer.replace(rule, function (err) {
-        if (err) { return done(err); }
-        expect(saveCommand.callCount).to.equal(3);
-        expect(saveCommand.calledWith(command)).to.be.true();
-        done();
-      });
-    });
-
-    it('should not save a command if an error occurred', function(done) {
-      var rule = {
-        action: 'replace',
-        search: 'alpha',
-        replace: 'beta'
-      };
-
-      var saveCommand = sinon.spy(transformer, 'saveCommand');
-
-      sinon.stub(transformer.driver, 'copy').yields();
-      sinon.stub(transformer.driver, 'remove').yields();
-      sinon.stub(transformer.driver, 'diff').yields();
-      sinon.stub(transformer.driver, 'sed')
-        .returns('command')
-        .yieldsAsync(new Error('Error'));
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt:10:---',
-        '/etc/file.txt:12:---',
-        '/etc/file.txt:14:---'
-      ].join('\n'))
-
-      transformer.replace(rule, function () {
-        expect(saveCommand.callCount).to.equal(0);
-        done();
-      });
-    });
-
     it('should make an original copy for each changed file', function (done) {
       var rule = {
         action: 'replace',

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -164,10 +164,9 @@ describe('Transformer', function() {
         search: 'a',
         replace: 'b',
         exclude: [
-          { name: 'file1.txt' },
-          { name: 'file2.txt', line: 22 },
-          { name: 'not-there.txt' },
-          { } // malformed excludes should be ignored
+          'file1.txt',
+          'file2.txt',
+          'not-there.txt'
         ]
       };
 
@@ -183,8 +182,7 @@ describe('Transformer', function() {
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
-        expect(sed.callCount).to.equal(2);
-        expect(sed.calledWith('a', 'b', '/etc/file2.txt', 78)).to.be.true();
+        expect(sed.callCount).to.equal(1);
         expect(sed.calledWith('a', 'b', '/etc/file3.txt', 182)).to.be.true();
         done();
       });
@@ -195,10 +193,9 @@ describe('Transformer', function() {
         search: 'a',
         replace: 'b',
         exclude: [
-          { name: 'applied.txt' },
-          { name: 'not-applied.txt' },
-          { name: 'file1.txt', line: 50 }, // applied
-          { name: 'file1.txt', line: 17 }  // not applied
+          'applied.txt',
+          'not-there',
+          'file1.txt'
         ]
       };
 
@@ -215,11 +212,9 @@ describe('Transformer', function() {
       transformer.replace(rule, function (err) {
         if (err) { return done(err); }
         var warnings = transformer.warnings;
-        expect(warnings.length).to.equal(2);
+        expect(warnings.length).to.equal(1);
         expect(warnings[0].rule).to.equal(rule.exclude[1]);
         expect(warnings[0].message).to.equal('Unused exclude.')
-        expect(warnings[1].rule).to.equal(rule.exclude[3]);
-        expect(warnings[1].message).to.equal('Unused exclude.')
         done();
       });
     });
@@ -228,9 +223,7 @@ describe('Transformer', function() {
       var rule = {
         search: 'a',
         replace: 'b',
-        exclude: [
-          { name: 'file1.txt' }
-        ]
+        exclude: ['file1.txt']
       };
 
       var sed = sinon.stub(transformer.driver, 'sed').yields();

--- a/test/transformer/util.js
+++ b/test/transformer/util.js
@@ -27,8 +27,6 @@ describe('Transformer', function() {
       expect(transformer.results).to.not.be.empty();
       var result = transformer.results[0];
       expect(result.rule).to.equal(rule);
-      expect(result.commands).to.be.an.array();
-      expect(result.commands).to.be.empty();
       expect(result.warnings).to.be.an.array();
       expect(result.warnings).to.be.empty();
       expect(result.nameChanges).to.be.an.array();
@@ -153,25 +151,12 @@ describe('Transformer', function() {
   }); // end 'setAction & getAction'
 
   describe('getScript', function() {
-    it('should return a correctly composed shellscript', function(done) {
-      var ruleOne = { action: 'copy', source: 'foo', dest: 'bar' };
-      var commandOne = 'cp /etc/foo /etc/bar';
-      var ruleTwo = { action: 'replace', search: 'a', replace: 'b' };
-      var commandTwo = 'sed -i "" "22s/a/b/g" bar';
-
+    it('should use the ScriptGenerator class to generate scripts', function(done) {
       var transformer = new Transformer('/etc', []);
-      transformer.saveCommand(commandOne, ruleOne);
-      transformer.saveCommand(commandTwo, ruleTwo);
-
-      var script = transformer.getScript();
-
-      expect(script).to.be.a.string();
-      expect(script.indexOf('#!/bin/sh')).to.equal(0);
-      expect(script.indexOf(commandOne)).to.be.above(-1);
-      expect(script.indexOf(commandTwo)).to.be.above(-1);
-      expect(script.indexOf(JSON.stringify(ruleOne))).to.be.above(-1);
-      expect(script.indexOf(JSON.stringify(ruleTwo))).to.be.above(-1);
-
+      var result = 'anbksnklnsskqlnskal2202';
+      sinon.stub(transformer.scriptGenerator, 'generate').returns(result);
+      expect(transformer.getScript()).to.equal(result);
+      expect(transformer.scriptGenerator.generate.calledOnce).to.be.true();
       done();
     });
   }); // end 'getScript'


### PR DESCRIPTION
This makes the generated scripts more robust and adaptable. Here's an overview:

1. Scripts are now generated directly from the rules, as opposed to from the commands run by the Transformer itself.
2. The script preamble has been cleaned up and helper functions were added.
3. Replace rule is now implemented fully in `sh`.
4. When commands fail they use the new helper functions to provide a better understanding to the end user what went wrong.

Finally, since we don't need it I completely removed line excludes from the replace rule.
