### PR TITLE
Better Diffs

### DIFF
--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -270,7 +270,7 @@ FsDriver.prototype.diff = function (a, b, cb) {
   this.exec(command, function (err, diff, scriptCommand) {
     // `diff` returns 1 when there are differences and > 1 when there is trouble
     if (err && err.code > 1) { return cb(err); }
-    // Make all diff references relative to the repository root (left means
+    // Make all diff references relative to the root (left means
     // before transform rule is applied, right means after)
     diff = diff.replace(new RegExp(self.root, 'g'), '')
       .replace(new RegExp(self.working, 'g'), '');

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -356,6 +356,5 @@ FsDriver.prototype.removeWorkingDirectory = function (cb) {
  *   diff.
  */
 FsDriver.prototype.workingDiff = function (cb) {
-  var self = this;
   this.diff(this.root, this.working, cb);
 };

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -261,6 +261,7 @@ FsDriver.prototype.exists = function (path) {
  *   completes.
  */
 FsDriver.prototype.diff = function (a, b, cb) {
+  var self = this;
   var command = [
     'diff -u -r',
     this.absolutePath(a),
@@ -269,6 +270,10 @@ FsDriver.prototype.diff = function (a, b, cb) {
   this.exec(command, function (err, diff, scriptCommand) {
     // `diff` returns 1 when there are differences and > 1 when there is trouble
     if (err && err.code > 1) { return cb(err); }
+    // Make all diff references relative to the repository root (left means
+    // before transform rule is applied, right means after)
+    diff = diff.replace(new RegExp(self.root, 'g'), '')
+      .replace(new RegExp(self.working, 'g'), '');
     cb(null, diff, scriptCommand);
   });
 };
@@ -351,5 +356,6 @@ FsDriver.prototype.removeWorkingDirectory = function (cb) {
  *   diff.
  */
 FsDriver.prototype.workingDiff = function (cb) {
+  var self = this;
   this.diff(this.root, this.working, cb);
 };

--- a/test/fixtures/fs-helper.js
+++ b/test/fixtures/fs-helper.js
@@ -22,6 +22,7 @@ var testPath = path.resolve(__dirname, 'test');
  */
 module.exports = {
   path: testPath,
+  mock: mockPath,
   createTestDir: createTestDir,
   removeTestDir: removeTestDir,
   exists: exists,

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -267,7 +267,7 @@ describe('fs-driver', function () {
       it('should ignore errors with code 1 (indicated differences)', function (done) {
         var error = new Error('diff error');
         error.code = 1;
-        driver.exec.yields(error, 'diff', 'command');
+        driver.exec.yieldsAsync(error, 'diff', 'command');
         driver.diff('a', 'b', function (err) {
           expect(err).to.be.null();
           done();

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -284,7 +284,7 @@ describe('fs-driver', function () {
         });
       });
 
-      it('should make paths relative to the repository root', function(done) {
+      it('should have paths that are relative to the root directory', function(done) {
         var absoluteDiff = driver.working + '\n' + driver.root + '\n';
         driver.exec.yieldsAsync(null, absoluteDiff, 'command');
         driver.diff('a', 'b', function (err, diff) {


### PR DESCRIPTION
Diffs had absolute paths to the working and root directories when performing transformation rules. This simply makes all diff paths relative. The user can assume that the left (or first) file will refer to the original, and the right (or after) file will refer to the file after performing the transformation.