### PR TITLE
Better "Per Rule" Diffs

### DIFF
--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -92,6 +92,22 @@ FsDriver.prototype.absolutePath = function (path) {
 };
 
 /**
+ * Strips absolute path prefixes for working and root directory from the
+ * given string.
+ *
+ * Note: This is here because the driver requires absolute paths to perform file
+ * system operations, but any resulting information should always be reported
+ * relative to the root directory. This is mostly used to have diffs make sense.
+ *
+ * @param {string} str String from which to strip absolute paths.
+ * @return {string} The string with sans absolute paths.
+ */
+FsDriver.prototype.stripAbsolutePaths = function (str) {
+  return str.replace(new RegExp(this.root, 'g'), '')
+    .replace(new RegExp(this.working, 'g'), '');
+};
+
+/**
  * Logs and executes a command.
  * @param {string} command Command to execute.
  * @param {fs-driver~ExecCallback} cb Callback to execute after command
@@ -270,11 +286,9 @@ FsDriver.prototype.diff = function (a, b, cb) {
   this.exec(command, function (err, diff, scriptCommand) {
     // `diff` returns 1 when there are differences and > 1 when there is trouble
     if (err && err.code > 1) { return cb(err); }
-    // Make all diff references relative to the root (left means
-    // before transform rule is applied, right means after)
-    diff = diff.replace(new RegExp(self.root, 'g'), '')
-      .replace(new RegExp(self.working, 'g'), '');
-    cb(null, diff, scriptCommand);
+    // Diff file references need to be relative to the root (left means before
+    // transform rule is applied, right means after)
+    cb(null, self.stripAbsolutePaths(diff), scriptCommand);
   });
 };
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -103,16 +103,16 @@ Transformer.prototype.addNameChange = function (from, to) {
 };
 
 /**
- * Adds a diff to the current result.
+ * Sets a diff for a given file to the current result.
  * @param {string} filename Name of the file for the diff.
  * @param {string} Contents of the diff (via diff -u, similar to git diff).
  */
-Transformer.prototype.addDiff = function (filename, diff) {
+Transformer.prototype.setFileDiff = function (filename, diff) {
   if (!this.currentResult) { return; }
-  if (!this.currentResult.diffs[filename]) {
-    this.currentResult.diffs[filename] = [];
-  }
-  this.currentResult.diffs[filename].push(diff);
+  // Note: Since this is being reported to the client, we need to remove any
+  // absolute paths to the root directory.
+  var relativePath = this.driver.stripAbsolutePaths(filename);
+  this.currentResult.diffs[relativePath] = diff;
 };
 
 /**
@@ -494,7 +494,7 @@ Transformer.prototype.replace = function (rule, cb) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           self.driver.diff(copyName, name, function (err, diff) {
             if (err) { return diffCallback(err); }
-            self.addDiff(name, diff);
+            self.setFileDiff(name, diff);
             diffCallback();
           });
         }, cb);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -490,10 +490,17 @@ Transformer.prototype.replace = function (rule, cb) {
 
       // 3.3 Collect diffs for each file
       function collectDiffs(cb) {
+        // Used to remove the original postfix from the left hand file name
+        // of resulting diffs.
+        var postfixExp = new RegExp(Transformer.ORIGINAL_POSTFIX, 'g');
+
         async.each(filenames, function (name, diffCallback) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           self.driver.diff(copyName, name, function (err, diff) {
             if (err) { return diffCallback(err); }
+            if (diff && diff.length > 0) {
+              diff = diff.replace(postfixExp, '');
+            }
             self.setFileDiff(name, diff);
             diffCallback();
           });

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -345,7 +345,7 @@ describe('Transformer', function() {
 
       var deltas = 'this is a delta';
       var diff = sinon.stub(transformer.driver, 'diff').yields(null, deltas);
-      var addDiff = sinon.spy(transformer, 'addDiff');
+      var setFileDiff = sinon.spy(transformer, 'setFileDiff');
       sinon.stub(transformer.driver, 'sed').yieldsAsync();
       sinon.stub(transformer.driver, 'copy').yields();
       sinon.stub(transformer.driver, 'remove').yields();
@@ -358,7 +358,7 @@ describe('Transformer', function() {
       transformer.replace(rule, function (err) {
         if (err) { return done(err); }
         expect(diff.callCount).to.equal(2);
-        expect(addDiff.callCount).to.equal(2);
+        expect(setFileDiff.callCount).to.equal(2);
         done();
       });
     });

--- a/test/transformer/util.js
+++ b/test/transformer/util.js
@@ -96,39 +96,37 @@ describe('Transformer', function() {
     });
   }); // end 'addNameChange'
 
-  describe('addDiff', function() {
-    it('should add the diff to the current result', function (done) {
-      var transformer = new Transformer('/', []);
+  describe('setFileDiff', function() {
+    it('should set the file diff on the current result', function (done) {
+      var transformer = new Transformer('/etc', []);
       var result = transformer.pushResult({ action: 'replace' });
       var filename = '/etc/file1.txt';
+      var relativePath = transformer.driver.stripAbsolutePaths(filename);
       var diff = 'THIS IS SPARTA';
-      transformer.addDiff(filename, diff);
-      expect(result.diffs[filename]).to.be.an.array();
-      expect(result.diffs[filename]).to.not.be.empty();
-      expect(result.diffs[filename][0]).to.equal(diff);
+      transformer.setFileDiff(filename, diff);
+      expect(result.diffs[relativePath]).to.be.a.string();
+      expect(result.diffs[relativePath]).to.equal(diff);
       done();
     });
 
-    it('should add multiple diffs to the current result', function (done) {
-      var transformer = new Transformer('/', []);
+    it('should set multiple diffs to the current result', function (done) {
+      var transformer = new Transformer('/etc', []);
       var result = transformer.pushResult({ action: 'replace' });
       var filename = '/etc/file1.txt';
+      var relativePath = transformer.driver.stripAbsolutePaths(filename);
       var diff = 'THIS IS SPARTA';
       var filename2 = '/etc/file2.txt';
+      var relativePath2 = transformer.driver.stripAbsolutePaths(filename2);
       var diff2 = 'THIS IS ARTASPAY';
-      transformer.addDiff(filename, diff);
-      transformer.addDiff(filename, diff2);
-      transformer.addDiff(filename2, diff2);
-      expect(result.diffs[filename]).to.be.an.array();
-      expect(result.diffs[filename].length).to.equal(2);
-      expect(result.diffs[filename][0]).to.equal(diff);
-      expect(result.diffs[filename][1]).to.equal(diff2);
-      expect(result.diffs[filename2]).to.be.an.array();
-      expect(result.diffs[filename2]).to.not.be.empty();
-      expect(result.diffs[filename2][0]).to.equal(diff2);
+      transformer.setFileDiff(filename, diff);
+      transformer.setFileDiff(filename2, diff2);
+      expect(result.diffs[relativePath]).to.be.a.string();
+      expect(result.diffs[relativePath]).to.equal(diff);
+      expect(result.diffs[relativePath2]).to.be.a.string();
+      expect(result.diffs[relativePath2]).to.equal(diff2);
       done();
     });
-  }); // end 'addDiff'
+  }); // end 'setFileDiff'
 
   describe('setAction & getAction', function() {
     it('should set rule action handlers', function (done) {


### PR DESCRIPTION
The `Transformer.replace` rule action approach to storing diffs by rule was a little convoluted. It assumed that there would be multiple working states for a file (based on the sed commands being run). At some point this got changed to a single check at the end of all sed commands, but the logic for holding multiple revisions remained. Furthermore, the diffs were using the absolute path to the working directory version of the file. This is unneeded as we only care about the file relative to the root directory.

This PR addresses the issue by only storing a single diff per file, per rule and stripping absolute paths from key that addresses those diffs on the result object for a rule.