### PR TITLE
Faster Replace Rules

### DIFF
--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -219,7 +219,7 @@ FsDriver.prototype.copy = function (source, dest, cb) {
  */
 FsDriver.prototype.grep = function (text, cb) {
   this.exec([
-    'grep -rn',
+    'grep -rl',
     '\'' + FsDriver.escape(text) + '\'',
     this.working ? this.working : this.root
   ].join(' '), cb);
@@ -237,16 +237,12 @@ FsDriver.prototype.grep = function (text, cb) {
  * @param {string} search Search text to replace.
  * @param {string} replace Text used for replacements.
  * @param {string} path Path to the file.
- * @param {Number} line Line number on which to perform the replacement.
  * @param {fs-driver~ExecCallback} cb Callback to execute after the sed
  *   completes.
  */
-FsDriver.prototype.sed = function (search, replace, name, line, cb) {
+FsDriver.prototype.sed = function (search, replace, name, cb) {
   var pattern = [
-    line + 's',
-    FsDriver.escape(search),
-    FsDriver.escape(replace),
-    'g'
+    's', FsDriver.escape(search), FsDriver.escape(replace), 'g'
   ].join('/');
 
   var command = [

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -219,7 +219,7 @@ FsDriver.prototype.copy = function (source, dest, cb) {
  */
 FsDriver.prototype.grep = function (text, cb) {
   this.exec([
-    'grep -rl',
+    'grep -rlI',
     '\'' + FsDriver.escape(text) + '\'',
     this.working ? this.working : this.root
   ].join(' '), cb);

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -160,7 +160,7 @@ ScriptGenerator.prototype.replace = function (rule, index) {
   var replace = FsDriver.escape(rule.replace);
 
   var body = [
-    'results=($(grep -rl \'' + search + '\' $search_files))',
+    'results=($(grep -rlI \'' + search + '\' $search_files))',
     'excludes="' + excludes + '"',
     'if ((${#results[@]} > 0)); then',
     '  for name in $results',

--- a/lib/script-generator.js
+++ b/lib/script-generator.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var FsDriver = require('./fs-driver');
+var debug = require('debug');
+var trace = debug('fs-transform:script-generator:trace');
 
 /**
  * Generates shell scripts from transformation rules.
@@ -74,6 +76,7 @@ ScriptGenerator.prototype.preamble = function () {
  */
 ScriptGenerator.prototype.addRule = function (rule) {
   if (!rule.action) { return; }
+  trace('addRule: ' + JSON.stringify(rule));
   var index = this.ruleScripts.length + 1;
   var script = this.actionGenerators[rule.action](rule, index);
   this.ruleScripts.push(script);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -405,9 +405,9 @@ Transformer.prototype.replace = function (rule, cb) {
   }
 
   this.driver.grep(rule.search, function (err, grepResult) {
-    // 1. Determine files & lines from grep
+    // 1. Determine files from grep
     var files = grepResult.split('\n').filter(function (name) {
-      return !isEmpty(name) && !name.match(/^Binary/);
+      return !isEmpty(name);
     });
 
     // 1.1 If no files were returned by grep, issue a warning and return

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -499,12 +499,12 @@ Transformer.prototype.replace = function (rule, cb) {
 
       // 3.4 Cleanup temporary files
       function cleanup(cb) {
+        self.script.addRule(rule);
         async.each(files, function (name, removeCallback) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           var dotLastName = name + '.last';
           var names = [copyName, dotLastName].join(' ');
           self.driver.remove(names, removeCallback);
-          self.script.addRule(rule);
         }, cb);
       }
     ], cb);

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -6,6 +6,7 @@ var FsDriver = require('./fs-driver');
 var Warning = require('./warning');
 var ScriptGenerator = require('./script-generator');
 var exists = require('101/exists');
+var isEmpty = require('101/is-empty');
 var debug = require('debug');
 
 var fullDiffDebug = debug('fs-transform:full-diff');
@@ -404,14 +405,9 @@ Transformer.prototype.replace = function (rule, cb) {
   }
 
   this.driver.grep(rule.search, function (err, grepResult) {
-    var files = [];
-
     // 1. Determine files & lines from grep
-    grepResult.split('\n').forEach(function (line) {
-      var match = line.match(/(.*):(\d+):.*/);
-      if (match) {
-        files.push({ name: match[1], line: match[2] });
-      }
+    var files = grepResult.split('\n').filter(function (name) {
+      return !isEmpty(name) && !name.match(/^Binary/);
     });
 
     // 1.1 If no files were returned by grep, issue a warning and return
@@ -425,7 +421,7 @@ Transformer.prototype.replace = function (rule, cb) {
 
     // 2.0 Filter out global excludes
     files = files.filter(function (file) {
-      return !~self._globalExcludes.indexOf(file.name);
+      return !~self._globalExcludes.indexOf(file);
     });
 
     // 2.1 Keep track of when excludes are used to filter results
@@ -438,7 +434,7 @@ Transformer.prototype.replace = function (rule, cb) {
     files = files.filter(function (file) {
       var keepFile = true;
       exclude.forEach(function(name, index) {
-        if (self.driver.absolutePath(name) === file.name) {
+        if (self.driver.absolutePath(name) === file) {
           keepFile = false;
           ruleApplied[index] = true;
           return;
@@ -461,19 +457,10 @@ Transformer.prototype.replace = function (rule, cb) {
     }
 
     // 3. Perform Search and Replace
-
-    // 3.0 Collect the set of filenames for each of the files being changed.
-    var filenames = [];
-    files.forEach(function (file) {
-      if (!~filenames.indexOf(file.name)) {
-        filenames.push(file.name);
-      }
-    });
-
     async.series([
       // 3.1 Create an temporary copy for each file being changed
       function createOriginalCopy(cb) {
-        async.each(filenames, function (name, copyCallback) {
+        async.each(files, function (name, copyCallback) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           self.driver.copy(name, copyName, copyCallback);
         }, cb);
@@ -485,8 +472,7 @@ Transformer.prototype.replace = function (rule, cb) {
           self.driver.sed(
             search,
             replace,
-            file.name,
-            parseInt(file.line),
+            file,
             sedCallback
           );
         }, cb);
@@ -498,7 +484,7 @@ Transformer.prototype.replace = function (rule, cb) {
         // of resulting diffs.
         var postfixExp = new RegExp(Transformer.ORIGINAL_POSTFIX, 'g');
 
-        async.each(filenames, function (name, diffCallback) {
+        async.each(files, function (name, diffCallback) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           self.driver.diff(copyName, name, function (err, diff) {
             if (err) { return diffCallback(err); }
@@ -513,7 +499,7 @@ Transformer.prototype.replace = function (rule, cb) {
 
       // 3.4 Cleanup temporary files
       function cleanup(cb) {
-        async.each(filenames, function (name, removeCallback) {
+        async.each(files, function (name, removeCallback) {
           var copyName = name + Transformer.ORIGINAL_POSTFIX;
           var dotLastName = name + '.last';
           var names = [copyName, dotLastName].join(' ');

--- a/test/fixtures/replace-no-exclude.sh
+++ b/test/fixtures/replace-no-exclude.sh
@@ -5,7 +5,7 @@
 #   replace: "probably"
 # }
 
-results=($(grep -rl 'absolutely' $search_files))
+results=($(grep -rlI 'absolutely' $search_files))
 excludes=""
 if ((${#results[@]} > 0)); then
   for name in $results

--- a/test/fixtures/replace.sh
+++ b/test/fixtures/replace.sh
@@ -6,7 +6,7 @@
 #   excludes: [A.dmg, B.tar.gz]
 # }
 
-results=($(grep -rl 'whut' $search_files))
+results=($(grep -rlI 'whut' $search_files))
 excludes="A.dmg B.tar.gz"
 if ((${#results[@]} > 0)); then
   for name in $results

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -35,7 +35,7 @@ command -v rm >/dev/null 2>&1 || {
 #   replace: "\prod"
 # }
 
-results=($(grep -rl '\\sum' $search_files))
+results=($(grep -rlI '\\sum' $search_files))
 excludes=""
 if ((${#results[@]} > 0)); then
   for name in $results

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -17,7 +17,6 @@ var noop = require('101/noop');
 describe('fs-driver', function () {
   describe('interface', function() {
     var driver = new FsDriver();
-
     it('should export the `FsDriver` class', function (done) {
       expect(FsDriver).to.exist();
       expect(typeof FsDriver).to.equal('function');
@@ -193,7 +192,7 @@ describe('fs-driver', function () {
 
     describe('grep', function() {
       it('should use driver.exec to perform the grep', function(done) {
-        var command = 'grep -rl \'search\' /tmp';
+        var command = 'grep -rlI \'search\' /tmp';
         driver.grep('search', function () {
           expect(driver.exec.calledOnce).to.be.true();
           expect(driver.exec.calledWith(command)).to.be.true();
@@ -204,7 +203,7 @@ describe('fs-driver', function () {
       it('should properly escape search patterns', function(done) {
         driver.grep('\\lambda\'', function (err) {
           if (err) { return done(err); }
-          var command = 'grep -rl \'\\\\lambda\\\'\' /tmp';
+          var command = 'grep -rlI \'\\\\lambda\\\'\' /tmp';
           expect(driver.exec.calledWith(command))
             .to.be.true();
           done();
@@ -212,7 +211,7 @@ describe('fs-driver', function () {
       });
 
       it('should use the working directory when one is supplied', function(done) {
-        var command = 'grep -rl \'search\' /working';
+        var command = 'grep -rlI \'search\' /working';
         driver.working = '/working';
         driver.grep('search', function (err) {
           if (err) { return done(err); }

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -193,7 +193,7 @@ describe('fs-driver', function () {
 
     describe('grep', function() {
       it('should use driver.exec to perform the grep', function(done) {
-        var command = 'grep -rn \'search\' /tmp';
+        var command = 'grep -rl \'search\' /tmp';
         driver.grep('search', function () {
           expect(driver.exec.calledOnce).to.be.true();
           expect(driver.exec.calledWith(command)).to.be.true();
@@ -204,7 +204,7 @@ describe('fs-driver', function () {
       it('should properly escape search patterns', function(done) {
         driver.grep('\\lambda\'', function (err) {
           if (err) { return done(err); }
-          var command = 'grep -rn \'\\\\lambda\\\'\' /tmp';
+          var command = 'grep -rl \'\\\\lambda\\\'\' /tmp';
           expect(driver.exec.calledWith(command))
             .to.be.true();
           done();
@@ -212,7 +212,7 @@ describe('fs-driver', function () {
       });
 
       it('should use the working directory when one is supplied', function(done) {
-        var command = 'grep -rn \'search\' /working';
+        var command = 'grep -rl \'search\' /working';
         driver.working = '/working';
         driver.grep('search', function (err) {
           if (err) { return done(err); }
@@ -225,8 +225,8 @@ describe('fs-driver', function () {
 
     describe('sed', function() {
       it('should use driver.exec to perform the sed', function(done) {
-        var command = 'sed -i.last \'1337s/bar/baz/g\' /tmp/file1.txt';
-        driver.sed('bar', 'baz', 'file1.txt', 1337, function () {
+        var command = 'sed -i.last \'s/bar/baz/g\' /tmp/file1.txt';
+        driver.sed('bar', 'baz', 'file1.txt', function () {
           expect(driver.exec.calledOnce).to.be.true();
           expect(driver.exec.calledWith(command)).to.be.true();
           done();
@@ -234,9 +234,9 @@ describe('fs-driver', function () {
       });
 
       it('should properly escape search and replace', function(done) {
-        driver.sed('/foo', '/bar', 'example.txt', 17, function (err) {
+        driver.sed('/foo', '/bar', 'example.txt', function (err) {
           if (err) { return done(err); }
-          var command = 'sed -i.last \'17s/\\/foo/\\/bar/g\' /tmp/example.txt';
+          var command = 'sed -i.last \'s/\\/foo/\\/bar/g\' /tmp/example.txt';
           expect(driver.exec.calledWith(command))
             .to.be.true();
           done();

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -137,28 +137,6 @@ describe('Transformer', function() {
       });
     });
 
-    it('should ignore binary files', function(done) {
-      var rule = {
-        search: 'a',
-        replace: 'b'
-      };
-
-      var sed = sinon.stub(transformer.driver, 'sed').yields();
-      sinon.stub(transformer.driver, 'copy').yields();
-      sinon.stub(transformer.driver, 'remove').yields();
-      sinon.stub(transformer.driver, 'diff').yields();
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        'Binary file /etc/example.bin matches',
-        '/etc/file1.txt'
-      ].join('\n'));
-
-      transformer.replace(rule, function (err) {
-        expect(sed.callCount).to.equal(1);
-        expect(sed.calledWith('a', 'b', '/etc/file1.txt')).to.be.true();
-        done();
-      });
-    });
-
     it('should apply global file excludes', function(done) {
       var rule = { search: 'koopa', replace: 'mario' };
       transformer.exclude({ files: ['file2.txt', 'file4.txt'] }, noop);

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -364,7 +364,6 @@ describe('Transformer', function() {
         search: 'alpha',
         replace: 'beta'
       };
-
       var remove = sinon.stub(transformer.driver, 'remove').yieldsAsync();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'sed').yieldsAsync();
@@ -389,6 +388,33 @@ describe('Transformer', function() {
           expect(remove.calledWith(originalName + ' ' + dotLastName))
             .to.be.true();
         });
+        done();
+      });
+    });
+
+    it('should only add the rule to the result script once', function(done) {
+      var rule = {
+        action: 'replace',
+        search: 'darn',
+        replace: 'yankees'
+      };
+      var remove = sinon.stub(transformer.driver, 'remove').yieldsAsync();
+      sinon.stub(transformer.driver, 'diff').yields();
+      sinon.stub(transformer.driver, 'sed').yieldsAsync();
+      sinon.stub(transformer.driver, 'copy').yields();
+      sinon.stub(transformer.driver, 'grep').yields(null, [
+        '/etc/file1.txt',
+        '/etc/file2.txt',
+        '/etc/file3.txt',
+        '/etc/file4.txt',
+        '/etc/file5.txt',
+        '/etc/file6.txt'
+      ].join('\n'));
+
+      sinon.spy(transformer.script, 'addRule');
+
+      transformer.replace(rule, function () {
+        expect(transformer.script.addRule.calledOnce).to.be.true();
         done();
       });
     });

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -123,16 +123,16 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:12:---',
-        '/etc/file2.txt:293:---'
+        '/etc/file1.txt',
+        '/etc/file2.txt'
       ].join('\n'));
 
       var rule = { action: 'replace', search: 'a', replace: 'b' };
       transformer.replace(rule, function (err) {
         if (err) { return done(err); }
         expect(sed.callCount).to.equal(2);
-        expect(sed.calledWith('a', 'b', '/etc/file1.txt', 12)).to.be.true();
-        expect(sed.calledWith('a', 'b', '/etc/file2.txt', 293)).to.be.true();
+        expect(sed.calledWith('a', 'b', '/etc/file1.txt')).to.be.true();
+        expect(sed.calledWith('a', 'b', '/etc/file2.txt')).to.be.true();
         done();
       });
     });
@@ -149,12 +149,12 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
         'Binary file /etc/example.bin matches',
-        '/etc/file1.txt:342:---'
+        '/etc/file1.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
         expect(sed.callCount).to.equal(1);
-        expect(sed.calledWith('a', 'b', '/etc/file1.txt', 342)).to.be.true();
+        expect(sed.calledWith('a', 'b', '/etc/file1.txt')).to.be.true();
         done();
       });
     });
@@ -168,20 +168,20 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:23:---',
-        '/etc/file2.txt:78:---',
-        '/etc/file3.txt:182:---',
-        '/etc/file4.txt:3232:---',
-        '/etc/suhweet/file4.txt:7:---'
+        '/etc/file1.txt',
+        '/etc/file2.txt',
+        '/etc/file3.txt',
+        '/etc/file4.txt',
+        '/etc/suhweet/file4.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
         expect(sed.callCount).to.equal(3);
-        expect(sed.calledWith('koopa', 'mario', '/etc/file1.txt', 23))
+        expect(sed.calledWith('koopa', 'mario', '/etc/file1.txt'))
           .to.be.true();
-        expect(sed.calledWith('koopa', 'mario', '/etc/file3.txt', 182))
+        expect(sed.calledWith('koopa', 'mario', '/etc/file3.txt'))
           .to.be.true();
-        expect(sed.calledWith('koopa', 'mario', '/etc/suhweet/file4.txt', 7))
+        expect(sed.calledWith('koopa', 'mario', '/etc/suhweet/file4.txt'))
           .to.be.true();
         done();
       });
@@ -203,15 +203,15 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:23:---',
-        '/etc/file2.txt:22:---',
-        '/etc/file2.txt:78:---',
-        '/etc/file3.txt:182:---'
+        '/etc/file1.txt',
+        '/etc/file2.txt',
+        '/etc/file2.txt',
+        '/etc/file3.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
         expect(sed.callCount).to.equal(1);
-        expect(sed.calledWith('a', 'b', '/etc/file3.txt', 182)).to.be.true();
+        expect(sed.calledWith('a', 'b', '/etc/file3.txt')).to.be.true();
         done();
       });
     });
@@ -232,9 +232,9 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/applied.txt:111:---',
-        '/etc/okay.txt:2384:---',
-        '/etc/file1.txt:50:---'
+        '/etc/applied.txt',
+        '/etc/okay.txt',
+        '/etc/file1.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
@@ -259,9 +259,9 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:50:---',
-        '/etc/file1.txt:89:---',
-        '/etc/file1.txt:123:---'
+        '/etc/file1.txt',
+        '/etc/file1.txt',
+        '/etc/file1.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
@@ -287,13 +287,9 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'diff').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt:10:---',
-        '/etc/file.txt:12:---',
-        '/etc/file.txt:14:---',
-        '/etc/file2.txt:182:---',
-        '/etc/file2.txt:12:---',
-        '/etc/file2.txt:16:---',
-        '/etc/file3.txt:162:---'
+        '/etc/file.txt',
+        '/etc/file2.txt',
+        '/etc/file3.txt'
       ].join('\n'))
 
       var fileNames = [
@@ -320,8 +316,8 @@ describe('Transformer', function() {
         replace: 'super'
       };
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt:10:---',
-        '/etc/file.txt:12:---',
+        '/etc/file.txt',
+        '/etc/file.txt',
       ].join('\n'));
       var sed = sinon.stub(transformer.driver, 'sed')
         .returns('command')
@@ -332,33 +328,6 @@ describe('Transformer', function() {
 
       transformer.replace(rule, function (err) {
         expect(sed.callCount).to.equal(0);
-        done();
-      });
-    });
-
-    it('should perform and save a diff for each changed file', function(done) {
-      var rule = {
-        action: 'replace',
-        search: 'alpha',
-        replace: 'beta'
-      };
-
-      var deltas = 'this is a delta';
-      var diff = sinon.stub(transformer.driver, 'diff').yields(null, deltas);
-      var setFileDiff = sinon.spy(transformer, 'setFileDiff');
-      sinon.stub(transformer.driver, 'sed').yieldsAsync();
-      sinon.stub(transformer.driver, 'copy').yields();
-      sinon.stub(transformer.driver, 'remove').yields();
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:10:---',
-        '/etc/file2.txt:12:---',
-        '/etc/file2.txt:14:---'
-      ].join('\n'));
-
-      transformer.replace(rule, function (err) {
-        if (err) { return done(err); }
-        expect(diff.callCount).to.equal(2);
-        expect(setFileDiff.callCount).to.equal(2);
         done();
       });
     });
@@ -377,9 +346,9 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'copy').yields();
       sinon.stub(transformer.driver, 'remove').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:10:---',
-        '/etc/file2.txt:12:---',
-        '/etc/file2.txt:14:---'
+        '/etc/file1.txt',
+        '/etc/file2.txt',
+        '/etc/file2.txt'
       ].join('\n'));
 
       transformer.replace(rule, function (err) {
@@ -401,10 +370,9 @@ describe('Transformer', function() {
       sinon.stub(transformer.driver, 'sed').yieldsAsync();
       sinon.stub(transformer.driver, 'copy').yields();
       sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt:10:---',
-        '/etc/file2.txt:12:---',
-        '/etc/file2.txt:14:---',
-        '/etc/file3.txt:293:---'
+        '/etc/file1.txt',
+        '/etc/file2.txt',
+        '/etc/file3.txt'
       ].join('\n'));
 
       var filenames = [


### PR DESCRIPTION
At one point we needed to filter replace rules by line, which required us to perform a `sed` command for each line that matched a search. This is no longer the case but we were still performing the by-line `sed` when applying a replace rule. This applies `sed` to the entire file instead of performing a replace line-by-line, significantly reducing the time cost for performing a replace rule.