### PR TITLE
SAN-3559; Secure Find and Replace

### DIFF
--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -117,7 +117,10 @@ class FsDriver {
       n = parseInt(1000000 * Math.random())
     }
     this.workingPath = workingPath + '.' + n
-    this.exec(`cp -r '${this.root}' '${this.workingPath}'`, cb)
+
+    const source = this.escapePath(this.root)
+    const dest = this.escapePath(this.workingPath)
+    this.exec(`cp -r ${source} ${dest}`, cb)
   }
 
   /**
@@ -131,7 +134,10 @@ class FsDriver {
       ))
     }
     this.resultsPath = `${this.workingPath}.results`
-    this.exec(`cp -r '${this.workingPath}' '${this.resultsPath}'`, cb)
+
+    const source = this.escapePath(this.workingPath)
+    const dest = this.escapePath(this.resultsPath)
+    this.exec(`cp -r ${source} ${dest}`, cb)
   }
 
   /**

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -36,7 +36,98 @@ class FsDriver {
     } else {
       this.root = path.resolve(root)
     }
-    this.working = null
+
+    this.workingPath = null
+    this.resultsPath = null
+  }
+
+  /**
+   * Sets up the working and results directory for the driver.
+   * @param  {Function} cb Called when setup is complete.
+   */
+  setup (cb) {
+    async.series([
+      this.createWorkingDirectory.bind(this),
+      this.createResultsDirectory.bind(this)
+    ], cb)
+  }
+
+  /**
+   * Tears down the working and results directories.
+   * @param  {boolean} commit Whether or not to commit changes to the original
+   *   root directory.
+   * @param  {Function} cb Callback to execute when the teardown is complete.
+   */
+  teardown (commit, cb) {
+    if (!commit) {
+      return async.series([
+        this.removeWorkingDirectory.bind(this),
+        this.removeResultsDirectory.bind(this)
+      ], cb)
+    }
+    var backupPath = this.root + '.bak'
+    this.exec([
+      `mv '${this.root}' '${backupPath}'`,
+      `mv '${this.workingPath}' '${this.root}'`,
+      `rm -rf '${backupPath}' '${this.resultsPath}'`,
+    ].join(' && '), cb)
+  }
+
+  /**
+   * Creates the initial working directory as a copy of the root directory.
+   * @param  {Function} cb Called when the directory has been created.
+   */
+  createWorkingDirectory (cb) {
+    let rootName = last(this.root.split('/'))
+    let workingPath = '/tmp/.' + rootName + '.fs-work'
+    let n = parseInt(1000000 * Math.random())
+    while (this.exists(workingPath + '.' + n)) {
+      n = parseInt(1000000 * Math.random())
+    }
+    this.workingPath = workingPath + '.' + n
+    this.exec(`cp -r '${this.root}' '${this.workingPath}'`, cb)
+  }
+
+  /**
+   * Creates the initial results directory to use for handling find and replace.
+   * @param  {Function} cb Called when the results directory has been created.
+   */
+  createResultsDirectory (cb) {
+    if (!this.workingPath) {
+      return cb(new Error(
+        'Cannot create a results directory without a working directory'
+      ))
+    }
+    this.resultsPath = `${this.workingPath}.results`
+    this.exec(`cp -r '${this.workingPath}' '${this.resultsPath}'`, cb)
+  }
+
+  /**
+   * Commits the changes made to the results directory back to the working
+   * directory.
+   * @param  {Function} cb Called when the changes have been committed.
+   */
+  commitResults (cb) {
+    this.exec([
+      `rm -rf '${this.workingPath}'`,
+      `cp -r '${this.resultsPath}' '${this.workingPath}'`
+    ].join('&&'), cb)
+  }
+
+  /**
+   * Removes the working directory.
+   * @param  {Function} cb Called when the working directory has been removed.
+   */
+  removeWorkingDirectory (cb) {
+    this.exec(`rm -rf '${this.workingPath}'`, cb)
+  }
+
+  /**
+   * Removes the results directory.
+   * @param  {Function} cb Called when the results directory has been removed.
+   */
+  removeResultsDirectory (cb) {
+    this.exec(`rm -rf '${this.resultsPath}'`, cb)
   }
 
   /**
@@ -46,7 +137,16 @@ class FsDriver {
    */
   static escape (str) {
     if (!isString(str)) { return str }
-    return str.replace(/(['/\\])/g, '\\$1')
+    return str.replace(/([$`'/\\])/g, '\\$1')
+  }
+
+  /**
+   * Returns a full diff between the working directory and the root directory.
+   * @param {fs-driver~ExecCallback} cb Callback to execute after performing the
+   *   diff.
+   */
+  workingDiff (cb) {
+    this.diff(this.root, this.workingPath, cb)
   }
 
   /**
@@ -72,7 +172,33 @@ class FsDriver {
     if (path.charAt(0) === '/') {
       return path
     }
-    return !this.working ? this.root + '/' + path : this.working + '/' + path
+
+    if (!this.resultsPath) {
+      return `${this.root}/${path}`
+    }
+    return `${this.resultsPath}/${path}`
+  }
+
+  /**
+   * Makes a relative path absolute to the working path for the driver.
+   * @param {string} path Path to make absolute.
+   * @return {string} The absolute path.
+   */
+  absoluteWorkingPath (path) {
+    if (!isString(path)) {
+      return null
+    }
+    if (path.charAt(0) === '/') {
+      return path
+    }
+    if (!this.workingPath) {
+      return `${this.root}/${path}`
+    }
+    return `${this.workingPath}/${path}`
+  }
+
+  absoluteRootPath (path) {
+    return `${this.root}/${path}`
   }
 
   /**
@@ -90,7 +216,8 @@ class FsDriver {
   stripAbsolutePaths (str) {
     return str
       .replace(new RegExp(this.root, 'g'), '')
-      .replace(new RegExp(this.working, 'g'), '')
+      .replace(new RegExp(this.workingPath, 'g'), '')
+      .replace(new RegExp(this.resultsPath, 'g'), '')
   }
 
   /**
@@ -104,11 +231,11 @@ class FsDriver {
     execLog(command)
     childProcess.exec(command, function (err, output) {
       var scriptCommand
-      if (!self.working) {
+      if (!self.resultsPath) {
         scriptCommand = command
       } else {
         scriptCommand = command.replace(
-          new RegExp(self.working + '([^\\s]*)', 'g'),
+          new RegExp(self.resultsPath + '([^\\s]*)', 'g'),
           self.root + '$1'
         )
       }
@@ -182,57 +309,6 @@ class FsDriver {
   }
 
   /**
-   * Performs a text search in the root directory and recursively for all
-   * subdirectories.
-   *
-   * @example
-   * // Recursively search for all text file occurances of the word 'foo'
-   * driver.grep('foo', function (err, result) {
-   *  // ...
-   * })
-   *
-   * @param {string} text Text to search for.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the grep
-   *   completes.
-   */
-  grep (text, cb) {
-    this.exec([
-      'grep -rlI',
-      '\'' + FsDriver.escape(text) + '\'',
-      this.working ? this.working : this.root
-    ].join(' '), cb)
-  }
-
-  /**
-   * Applies in-place text replacements.
-   *
-   * @example
-   * // Replaces 'foo' with 'bar' on line 42 of '/path/to/file'
-   * fsDriver('foo', 'bar', '/path/to/file', 42, function (err, result) {
-   *   // ...
-   * })
-   *
-   * @param {string} search Search text to replace.
-   * @param {string} replace Text used for replacements.
-   * @param {string} path Path to the file.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the sed
-   *   completes.
-   */
-  sed (search, replace, name, cb) {
-    var pattern = [
-      's', FsDriver.escape(search), FsDriver.escape(replace), 'g'
-    ].join('/')
-
-    var command = [
-      'sed -i.last',
-      '\'' + pattern + '\'',
-      this.absolutePath(name)
-    ].join(' ')
-
-    this.exec(command, cb)
-  }
-
-  /**
    * Determines if a path exists.
    * @param {string} path Absolute or relative path to check.
    * @return {boolean} `true` if the absolute path exists, false otherwise.
@@ -289,71 +365,13 @@ class FsDriver {
       this.absolutePath(filename)
     ].join(' '), cb)
   }
-
-  /**
-   * Attempts to find an available working directory relative to /tmp.
-   */
-  findWorkingDirectory () {
-    var rootName = last(this.root.split('/'))
-    var workingPath = '/tmp/.' + rootName + '.fs-work'
-    var n = Math.random()
-    while (this.exists(workingPath + '.' + n)) {
-      n = Math.random()
-    }
-    return workingPath + '.' + n
-  }
-
-  /**
-   * Creates a temporary working copy of the root directory. This copy is used
-   * to set the absolute path for given relative file names in various commands
-   * (e.g. move, copy, grep, sed, rm, etc.)
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the working
-   *   directory has been created.
-   */
-  createWorkingDirectory (cb) {
-    var self = this
-    var workingPath = this.findWorkingDirectory()
-    var copyCommand = ['cp -r', this.root, workingPath].join(' ')
-    this.exec(copyCommand, function (err) {
-      if (err) { return cb(err) }
-      self.working = workingPath
-      cb()
-    })
-  }
-
-  /**
-   * Removes the temporary working directory.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after removing the
-   *   temporary working directory.
-   */
-  removeWorkingDirectory (cb) {
-    var self = this
-    if (!this.working) { return cb() }
-    this.removeRecursive(this.working, function (err) {
-      if (err) { return cb(err) }
-      self.working = null
-      cb()
-    })
-  }
-
-  /**
-   * Returns a full diff between the working directory and the root directory.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after performing the
-   *   diff.
-   */
-  workingDiff (cb) {
-    this.diff(this.root, this.working, cb)
-  }
 }
 
 /**
  * Commands required to use the `FsDriver` class.
  * @type {array}
  */
-Object.defineProperty(FsDriver, 'commands', {
-  value: ['cp', 'mv', 'grep', 'sed', 'diff', 'rm'],
-  writable: false
-})
+FsDriver.commands = ['cp', 'mv', 'diff', 'rm']
 
 /**
  * Driver for performing filesystem operations.

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -176,6 +176,26 @@ class FsDriver {
   }
 
   /**
+   * Returns a full diff between the result directory and the working directory.
+   * @param  {Function} cb Called with the results of the diff.
+   */
+  resultDiff (cb) {
+    var self = this
+    var command = [
+      'diff -u -r',
+      this.escapePath(this.workingPath),
+      this.escapePath(this.resultsPath)
+    ].join(' ')
+    this.exec(command, function (err, diff, scriptCommand) {
+      // `diff` returns 1 when there are differences and > 1 on failure
+      if (err && err.code > 1) { return cb(err) }
+      // Diff file references need to be relative to the root (left means before
+      // transform rule is applied, right means after)
+      cb(null, self.stripAbsolutePaths(diff), scriptCommand)
+    })
+  }
+
+  /**
    * Makes a relative path absolute to the root directory of the driver. Returns
    * the original path if it is already absolute.
    *
@@ -237,8 +257,8 @@ class FsDriver {
   stripAbsolutePaths (str) {
     return str
       .replace(new RegExp(this.root, 'g'), '')
-      .replace(new RegExp(this.workingPath, 'g'), '')
       .replace(new RegExp(this.resultsPath, 'g'), '')
+      .replace(new RegExp(this.workingPath, 'g'), '')
   }
 
   /**

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -155,20 +155,20 @@ class FsDriver {
   }
 
   /**
-   * Returns a full diff between the working directory and the root directory.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after performing the
-   *   diff.
+   * Performs a diff over two given paths.
+   * @param {string} a First path.
+   * @param {string} b Second path.
+   * @param {function} cb Callback to execute with the diff results.
    */
-  workingDiff (cb) {
+  diff (a, b, cb) {
     var self = this
     var command = [
-      'diff -u -r',
-      this.escapePath(this.root),
-      this.escapePath(this.workingPath)
+      'diff -u -r', this.escapePath(a), this.escapePath(b)
     ].join(' ')
     this.exec(command, function (err, diff, scriptCommand) {
       // `diff` returns 1 when there are differences and > 1 on failure
       if (err && err.code > 1) { return cb(err) }
+
       // Diff file references need to be relative to the root (left means before
       // transform rule is applied, right means after)
       cb(null, self.stripAbsolutePaths(diff), scriptCommand)
@@ -176,23 +176,20 @@ class FsDriver {
   }
 
   /**
+   * Returns a full diff between the working directory and the root directory.
+   * @param {fs-driver~ExecCallback} cb Callback to execute after performing the
+   *   diff.
+   */
+  workingDiff (cb) {
+    this.diff(this.root, this.workingPath, cb)
+  }
+
+  /**
    * Returns a full diff between the result directory and the working directory.
    * @param  {Function} cb Called with the results of the diff.
    */
-  resultDiff (cb) {
-    var self = this
-    var command = [
-      'diff -u -r',
-      this.escapePath(this.workingPath),
-      this.escapePath(this.resultsPath)
-    ].join(' ')
-    this.exec(command, function (err, diff, scriptCommand) {
-      // `diff` returns 1 when there are differences and > 1 on failure
-      if (err && err.code > 1) { return cb(err) }
-      // Diff file references need to be relative to the root (left means before
-      // transform rule is applied, right means after)
-      cb(null, self.stripAbsolutePaths(diff), scriptCommand)
-    })
+  resultsDiff (cb) {
+    this.diff(this.workingPath, this.resultsPath, cb)
   }
 
   /**

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -23,6 +23,18 @@ var execLog = debug('fs-transform:exec')
  */
 class FsDriver {
   /**
+   * Escapes a string for use in a command.
+   * @param {string} str String to escape.
+   * @return {string} The command line escaped string.
+   */
+  static escape (str) {
+    if (!isString(str)) {
+      str = str.toString()
+    }
+    return str.replace(/(['/\\])/g, '\\$1')
+  }
+
+  /**
    * Creates a new filesystem driver.
    * @param {string} root Path to use for operations.
    */
@@ -39,6 +51,19 @@ class FsDriver {
 
     this.workingPath = null
     this.resultsPath = null
+  }
+
+  /**
+   * Escapes strings for use in paths via shell commands. Roughly this simply
+   * removes all inner single quotes and wraps the path in single quotes.
+   * @param {string} file Path to the file
+   * @return {string} The escaped and single quoted path to the file.
+   */
+  escapePath (file) {
+    if (!isString(file)) {
+      return ''
+    }
+    return `'${file.replace(/[']/g, '')}'`
   }
 
   /**
@@ -59,18 +84,25 @@ class FsDriver {
    * @param  {Function} cb Callback to execute when the teardown is complete.
    */
   teardown (commit, cb) {
-    if (!commit) {
-      return async.series([
-        this.removeWorkingDirectory.bind(this),
-        this.removeResultsDirectory.bind(this)
-      ], cb)
+    const rootPath = this.escapePath(this.root)
+    const backupPath = this.escapePath(this.root + '.bak')
+    const workingPath = this.escapePath(this.workingPath)
+    const resultsPath = this.escapePath(this.resultsPath)
+
+    let commands = [
+      `rm -rf ${workingPath}`,
+      `rm -rf ${resultsPath}`
+    ]
+
+    if (commit) {
+      commands = [
+        `mv ${rootPath} ${backupPath}`,
+        `mv ${workingPath} ${rootPath}`,
+        `rm -rf ${backupPath} ${resultsPath}`
+      ]
     }
-    var backupPath = this.root + '.bak'
-    this.exec([
-      `mv '${this.root}' '${backupPath}'`,
-      `mv '${this.workingPath}' '${this.root}'`,
-      `rm -rf '${backupPath}' '${this.resultsPath}'`,
-    ].join(' && '), cb)
+
+    this.exec(commands.join(' && '), cb)
   }
 
   /**
@@ -108,36 +140,12 @@ class FsDriver {
    * @param  {Function} cb Called when the changes have been committed.
    */
   commitResults (cb) {
+    const workingPath = this.escapePath(this.workingPath)
+    const resultsPath = this.escapePath(this.resultsPath)
     this.exec([
-      `rm -rf '${this.workingPath}'`,
-      `cp -r '${this.resultsPath}' '${this.workingPath}'`
-    ].join('&&'), cb)
-  }
-
-  /**
-   * Removes the working directory.
-   * @param  {Function} cb Called when the working directory has been removed.
-   */
-  removeWorkingDirectory (cb) {
-    this.exec(`rm -rf '${this.workingPath}'`, cb)
-  }
-
-  /**
-   * Removes the results directory.
-   * @param  {Function} cb Called when the results directory has been removed.
-   */
-  removeResultsDirectory (cb) {
-    this.exec(`rm -rf '${this.resultsPath}'`, cb)
-  }
-
-  /**
-   * Escapes a string for use in a command.
-   * @param {string} str String to escape.
-   * @return {string} The command line escaped string.
-   */
-  static escape (str) {
-    if (!isString(str)) { return str }
-    return str.replace(/([$`'/\\])/g, '\\$1')
+      `rm -rf ${workingPath}`,
+      `cp -r ${resultsPath} ${workingPath}`
+    ].join(' && '), cb)
   }
 
   /**
@@ -146,7 +154,19 @@ class FsDriver {
    *   diff.
    */
   workingDiff (cb) {
-    this.diff(this.root, this.workingPath, cb)
+    var self = this
+    var command = [
+      'diff -u -r',
+      this.escapePath(this.root),
+      this.escapePath(this.workingPath)
+    ].join(' ')
+    this.exec(command, function (err, diff, scriptCommand) {
+      // `diff` returns 1 when there are differences and > 1 on failure
+      if (err && err.code > 1) { return cb(err) }
+      // Diff file references need to be relative to the root (left means before
+      // transform rule is applied, right means after)
+      cb(null, self.stripAbsolutePaths(diff), scriptCommand)
+    })
   }
 
   /**
@@ -165,14 +185,13 @@ class FsDriver {
    * @return {string} An absolute path relative to the root for a relative path,
    *  or just the path if it was already absolute.
    */
-  absolutePath (path) {
+  absoluteResultsPath (path) {
     if (!isString(path)) {
       return null
     }
     if (path.charAt(0) === '/') {
       return path
     }
-
     if (!this.resultsPath) {
       return `${this.root}/${path}`
     }
@@ -195,10 +214,6 @@ class FsDriver {
       return `${this.root}/${path}`
     }
     return `${this.workingPath}/${path}`
-  }
-
-  absoluteRootPath (path) {
-    return `${this.root}/${path}`
   }
 
   /**
@@ -281,8 +296,8 @@ class FsDriver {
   move (source, dest, cb) {
     this.exec([
       'mv',
-      this.absolutePath(source),
-      this.absolutePath(dest)
+      this.escapePath(this.absoluteResultsPath(source)),
+      this.escapePath(this.absoluteResultsPath(dest))
     ].join(' '), cb)
   }
 
@@ -303,8 +318,8 @@ class FsDriver {
   copy (source, dest, cb) {
     this.exec([
       'cp',
-      this.absolutePath(source),
-      this.absolutePath(dest)
+      this.escapePath(this.absoluteResultsPath(source)),
+      this.escapePath(this.absoluteResultsPath(dest))
     ].join(' '), cb)
   }
 
@@ -314,56 +329,7 @@ class FsDriver {
    * @return {boolean} `true` if the absolute path exists, false otherwise.
    */
   exists (path) {
-    return fs.existsSync(this.absolutePath(path))
-  }
-
-  /**
-   * Performs a file diff.
-   * @param {string} a Name of the first file for the diff.
-   * @param {string} b Name of the second file.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the diff
-   *   completes.
-   */
-  diff (a, b, cb) {
-    var self = this
-    var command = [
-      'diff -u -r',
-      this.absolutePath(a),
-      this.absolutePath(b)
-    ].join(' ')
-    this.exec(command, function (err, diff, scriptCommand) {
-      // `diff` returns 1 when there are differences and > 1 on failure
-      if (err && err.code > 1) { return cb(err) }
-      // Diff file references need to be relative to the root (left means before
-      // transform rule is applied, right means after)
-      cb(null, self.stripAbsolutePaths(diff), scriptCommand)
-    })
-  }
-
-  /**
-   * Removes a file.
-   * @param {string} filename Name of the file to remove.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the remove
-   *   completes.
-   */
-  remove (filename, cb) {
-    this.exec([
-      'rm',
-      this.absolutePath(filename)
-    ].join(' '), cb)
-  }
-
-  /**
-   * Recursively removes a file or directory.
-   * @param {string} filename Name of the file to remove.
-   * @param {fs-driver~ExecCallback} cb Callback to execute after the remove
-   *   completes.
-   */
-  removeRecursive (filename, cb) {
-    this.exec([
-      'rm -rf',
-      this.absolutePath(filename)
-    ].join(' '), cb)
+    return fs.existsSync(this.absoluteResultsPath(path))
   }
 }
 

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -3,6 +3,7 @@
 var async = require('async')
 var childProcess = require('child_process')
 var debug = require('debug')
+var exists = require('101/exists')
 var fs = require('fs')
 var isString = require('101/is-string')
 var last = require('101/last')
@@ -106,10 +107,15 @@ class FsDriver {
   }
 
   /**
-   * Creates the initial working directory as a copy of the root directory.
+   * Creates the initial working directory as a copy of the root directory. This
+   * method has no effect if there is already a working directory.
    * @param  {Function} cb Called when the directory has been created.
    */
   createWorkingDirectory (cb) {
+    if (exists(this.workingPath)) {
+      return cb()
+    }
+
     let rootName = last(this.root.split('/'))
     let workingPath = '/tmp/.' + rootName + '.fs-work'
     let n = parseInt(1000000 * Math.random())
@@ -128,7 +134,11 @@ class FsDriver {
    * @param  {Function} cb Called when the results directory has been created.
    */
   createResultsDirectory (cb) {
-    if (!this.workingPath) {
+    if (exists(this.resultsPath)) {
+      return cb()
+    }
+
+    if (!exists(this.workingPath)) {
       return cb(new Error(
         'Cannot create a results directory without a working directory'
       ))

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -1,0 +1,99 @@
+'use strict'
+
+const finder = require('findit')
+const path = require('path')
+const Promise = require('bluebird')
+const replaceStream = require('replacestream')
+
+const childProcess = Promise.promisifyAll(require('child_process'))
+const fs = Promise.promisifyAll(require('fs'))
+
+const IGNORE = ['.git', 'node_modules/']
+const RESULTS_DIR = 'results'
+
+/**
+ * Performs find-and-replace actions on the given working directory.
+ * @class
+ * @author Ryan Sandor Richards
+ */
+module.exports = class Replacer {
+  /**
+   * Creates a new replace transform.
+   * @param {string} readPath Path from which to read files.
+   * @param {string} working Path to write changes for files.
+   * @param {array} ignore A list of paths to ignore during the
+   *   find-and-replace.
+   */
+  constructor (readPath, resultsPath, ignore) {
+    this.readPath = readPath
+    this.resultsPath = resultsPath
+    this.ignore = IGNORE.concat(ignore || [])
+  }
+
+  /**
+   * Determines whether or not the given file is allowed.
+   * @return {boolean} `true` if the file is allowed, `false` otherwise.
+   */
+  allowFile (file, rule) {
+    for (let i = 0; i < this.ignore.length; i++) {
+      if (~file.indexOf(this.ignore[i])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  /**
+   * Walks the file tree of the root directory and finds a list of paths to
+   * files relevant to the search and replace.
+   * @return {Promise} Resolves with a list of all applicable files in the root
+   *   directory.
+   */
+  getFiles () {
+    return new Promise((resolve, reject) => {
+      const files = []
+      finder(this.readPath)
+        .on('directory', (dir, stat, stop) => {
+          if (!this.allowFile(dir)) {
+            stop()
+          }
+        })
+        .on('file', (file, stat) => {
+          files.push(file)
+        })
+        .on('error', reject)
+        .on('end', () => {
+          resolve(files.filter((file) => {
+            return this.allowFile(file)
+          }))
+        })
+    })
+  }
+
+  /**
+   * Performs a find-and-replace on the filesystem.
+   * @param {object} rule The find-and-replace rule to apply.
+   */
+  replace (query, replace) {
+    var self = this
+    return this.getFiles()
+      .then(function (files) {
+        return Promise.all(files.map(function (file) {
+          return new Promise(function (resolve, reject) {
+            var findAndReplace = replaceStream(
+              query,
+              replace,
+              { ignoreCase: false }
+            )
+            findAndReplace.on('end', resolve)
+            findAndReplace.on('error', reject)
+            fs.createReadStream(file)
+              .pipe(findAndReplace)
+              .pipe(fs.createWriteStream(
+                file.replace(self.readPath, self.resultsPath)
+              ))
+          })
+        }))
+      })
+  }
+}

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -1,15 +1,11 @@
 'use strict'
 
 const finder = require('findit')
-const path = require('path')
 const Promise = require('bluebird')
 const replaceStream = require('replacestream')
-
-const childProcess = Promise.promisifyAll(require('child_process'))
 const fs = Promise.promisifyAll(require('fs'))
 
 const IGNORE = ['.git', 'node_modules/']
-const RESULTS_DIR = 'results'
 
 /**
  * Performs find-and-replace actions on the given working directory.

--- a/lib/replacer.js
+++ b/lib/replacer.js
@@ -12,7 +12,22 @@ const IGNORE = ['.git', 'node_modules/']
  * @class
  * @author Ryan Sandor Richards
  */
-module.exports = class Replacer {
+class Replacer {
+  /**
+   * Performs a find and replace.
+   * @param {string} readPath Path from which to read files.
+   * @param {string} working Path to write changes for files.
+   * @param {array} ignore A list of paths to ignore during the
+   *   find-and-replace.
+   * @param {string} query Query to find.
+   * @param {string} replace Replacement to make.
+   * @return {Promise} Resolves when the find and replace is complete.
+   */
+  static findAndReplace (readPath, resultsPath, ignore, query, replace) {
+    const replacer = new Replacer(readPath, resultsPath, ignore)
+    return replacer.replace(query, replace)
+  }
+
   /**
    * Creates a new replace transform.
    * @param {string} readPath Path from which to read files.
@@ -23,7 +38,7 @@ module.exports = class Replacer {
   constructor (readPath, resultsPath, ignore) {
     this.readPath = readPath
     this.resultsPath = resultsPath
-    this.ignore = IGNORE.concat(ignore || [])
+    this.ignore = IGNORE.concat(ignore)
   }
 
   /**
@@ -93,3 +108,5 @@ module.exports = class Replacer {
       })
   }
 }
+
+module.exports = Replacer

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -361,14 +361,15 @@ class Transformer {
       exclude = []
     }
 
-    var replacer = new Replacer(
-      this.driver.workingPath,
-      this.driver.resultsPath,
-      this._globalExcludes.concat(exclude)
-    )
-
-    replacer.replace(rule.search, rule.replace)
-      .then(function (files) {
+    Replacer
+      .findAndReplace(
+        this.driver.workingPath,
+        this.driver.resultsPath,
+        this._globalExcludes.concat(exclude),
+        rule.search,
+        rule.replace
+      )
+      .then(function () {
         // Add the rule to the script
         self.script.addRule(rule)
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -373,7 +373,7 @@ class Transformer {
         self.script.addRule(rule)
 
         // Set the diffs for each file
-        self.driver.resultDiff((err, diff) => {
+        self.driver.resultsDiff((err, diff) => {
           if (err) { return cb(err) }
           let entries = diff.split('diff -u -r ')
           entries.shift()

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -374,7 +374,7 @@ class Transformer {
 
         // Set the diffs for each file
         self.driver.resultDiff((err, diff) => {
-          if (err) { return cb(err); }
+          if (err) { return cb(err) }
           let entries = diff.split('diff -u -r ')
           entries.shift()
           entries.forEach((diff) => {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -6,7 +6,6 @@ var FsDriver = require('./fs-driver')
 var Warning = require('./warning')
 var ScriptGenerator = require('./script-generator')
 var exists = require('101/exists')
-var isEmpty = require('101/is-empty')
 var debug = require('debug')
 var Replacer = require('./replacer')
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -369,8 +369,22 @@ class Transformer {
 
     replacer.replace(rule.search, rule.replace)
       .then(function (files) {
+        // Add the rule to the script
         self.script.addRule(rule)
-        cb()
+
+        // Set the diffs for each file
+        self.driver.resultDiff((err, diff) => {
+          if (err) { return cb(err); }
+          let entries = diff.split('diff -u -r ')
+          entries.shift()
+          entries.forEach((diff) => {
+            let lines = diff.split('\n')
+            let fileLine = lines.shift()
+            let filename = fileLine.split(/\s+/).pop()
+            self.setFileDiff(filename, lines.join('\n'))
+          })
+          cb()
+        })
       })
       .catch(cb)
   }

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -8,6 +8,7 @@ var ScriptGenerator = require('./script-generator')
 var exists = require('101/exists')
 var isEmpty = require('101/is-empty')
 var debug = require('debug')
+var Replacer = require('./replacer')
 
 var fullDiffDebug = debug('fs-transform:full-diff')
 
@@ -212,22 +213,25 @@ class Transformer {
         self.driver.hasAllCommands(cb)
       },
 
-      // 1. Create a working directory
-      function setu (cb) {
-        self.driver.createWorkingDirectory(cb)
+      // 1. Create initial working and results directory
+      function setup (cb) {
+        self.driver.setup(cb)
       },
 
       // 2. Apply transformation rules
-      function applyRule (cb) {
+      function applyRules (cb) {
         async.mapSeries(self.rules, function (rule, ruleCallback) {
-          self.applyRule(rule, ruleCallback)
+          self.applyRule(rule, function (err) {
+            if (err) { return ruleCallback(err) }
+            self.driver.commitResults(ruleCallback)
+          })
         }, function (err) {
           cb(err, self)
         })
       },
 
       // 3. Fetch a diff between the working and the original root
-      function fetchFullDif (cb) {
+      function fetchFullDiff (cb) {
         self.driver.workingDiff(function (err, diff) {
           if (err) { return cb(err) }
           fullDiffDebug(diff)
@@ -238,26 +242,8 @@ class Transformer {
 
       // 4. Commit the changes if applicable, otherwise remove the working
       //    directory.
-      function cleanu (cleanupCallback) {
-        if (!commit) {
-          return self.driver.removeWorkingDirectory(cleanupCallback)
-        }
-
-        var root = self.driver.root
-        var backup = root + '.bak'
-        var working = self.driver.working
-
-        async.series([
-          function backupRoo (cb) {
-            self.driver.move(root, backup, cb)
-          },
-          function moveWorkingToRoo (cb) {
-            self.driver.move(working, root, cb)
-          },
-          function removeBacku (cb) {
-            self.driver.removeRecursive(backup, cb)
-          }
-        ], cleanupCallback)
+      function cleanup (cleanupCallback) {
+        self.driver.teardown(commit, cleanupCallback)
       }
     ], function (err) {
       executeCallback(err, self)
@@ -370,119 +356,24 @@ class Transformer {
       return cb()
     }
 
-    var exclude = rule.exclude || []
+    var exclude = rule.exclude
     if (!Array.isArray(exclude)) {
       this.addWarning(rule, 'Excludes not supplied as an array, omitting.')
       exclude = []
     }
 
-    this.driver.grep(rule.search, function (err, grepResult) {
-      if (err) { return cb(err) }
+    var replacer = new Replacer(
+      this.driver.workingPath,
+      this.driver.resultsPath,
+      this._globalExcludes.concat(exclude)
+    )
 
-      // 1. Determine files from grep
-      var files = grepResult.split('\n').filter(function (name) {
-        return !isEmpty(name)
-      })
-
-      // 1.1 If no files were returned by grep, issue a warning and return
-      if (files.length === 0) {
-        self.addWarning(rule, 'Search did not return any results.')
+    replacer.replace(rule.search, rule.replace)
+      .then(function (files) {
         self.script.addRule(rule)
-        return cb()
-      }
-
-      // 2. Remove excluded files/lines from result set
-
-      // 2.0 Filter out global excludes and .git files
-      files = files.filter(function (file) {
-        return !~self._globalExcludes.indexOf(file) && !~file.indexOf('.git/')
+        cb()
       })
-
-      // 2.1 Keep track of when excludes are used to filter results
-      var ruleApplied = []
-      exclude.forEach(function (excludeRule, index) {
-        ruleApplied[index] = false
-      })
-
-      // 2.2 Handle local rule file excludes
-      files = files.filter(function (file) {
-        var keepFile = true
-        exclude.forEach(function (name, index) {
-          if (self.driver.absolutePath(name) === file) {
-            keepFile = false
-            ruleApplied[index] = true
-            return
-          }
-        })
-        return keepFile
-      })
-
-      // 2.3 Issue warnings for unused excludes
-      exclude.forEach(function (excludeRule, index) {
-        if (!ruleApplied[index]) {
-          self.addWarning(excludeRule, 'Unused exclude.')
-        }
-      })
-
-      // 2.4 Issue a warning and return if the excludes removed all files
-      if (files.length === 0) {
-        self.addWarning(rule, 'All results were excluded.')
-        return cb()
-      }
-
-      // 3. Perform Search and Replace
-      async.series([
-        // 3.1 Create an temporary copy for each file being changed
-        function createOriginalCop (cb) {
-          async.each(files, function (name, copyCallback) {
-            var copyName = name + Transformer.ORIGINAL_POSTFIX
-            self.driver.copy(name, copyName, copyCallback)
-          }, cb)
-        },
-
-        // 3.2 Make replacements by using sed
-        function sedFile (cb) {
-          async.each(files, function (file, sedCallback) {
-            self.driver.sed(
-              search,
-              replace,
-              file,
-              sedCallback
-            )
-          }, cb)
-        },
-
-        // 3.3 Collect diffs for each file
-        function collectDiff (cb) {
-          // Used to remove the original postfix from the left hand file name
-          // of resulting diffs.
-          var postfixExp = new RegExp(Transformer.ORIGINAL_POSTFIX, 'g')
-
-          async.each(files, function (name, diffCallback) {
-            var copyName = name + Transformer.ORIGINAL_POSTFIX
-            self.driver.diff(copyName, name, function (err, diff) {
-              if (err) { return diffCallback(err) }
-              if (diff && diff.length > 0) {
-                diff = diff.replace(postfixExp, '')
-              }
-              self.setFileDiff(name, diff)
-              diffCallback()
-            })
-          }, cb)
-        },
-
-        // 3.4 Cleanup temporary files
-        function cleanu (cb) {
-          self.script.addRule(rule)
-          async.each(files, function (name, removeCallback) {
-            var copyName = name + Transformer.ORIGINAL_POSTFIX
-            var dotLastName = name + '.last'
-            var names = [copyName, dotLastName].join(' ')
-            self.driver.remove(names, removeCallback)
-          }, cb)
-        }
-      ], cb)
-    })
+      .catch(cb)
   }
 
   /**
@@ -504,7 +395,7 @@ class Transformer {
         self.addWarning('Non-string exclude filename encountered.')
         return
       }
-      var absoluteName = self.driver.absolutePath(name)
+      var absoluteName = self.driver.absoluteWorkingPath(name)
       if (!~self._globalExcludes.indexOf(absoluteName)) {
         self._globalExcludes.push(absoluteName)
       }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "async": "^1.5.2",
     "bluebird": "^3.3.1",
     "debug": "^2.2.0",
-    "findit": "^2.0.0"
+    "findit": "^2.0.0",
+    "replacestream": "^4.0.0"
   },
   "devDependencies": {
     "code": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "101": "^1.4.0",
     "async": "^1.5.2",
     "bluebird": "^3.3.1",
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "findit": "^2.0.0"
   },
   "devDependencies": {
     "code": "^2.1.0",

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -35,12 +35,6 @@ describe('fs-driver', () => {
     })
   })
 
-  describe('escape', () => {
-    it('should remove harmful characters', (done) => {
-      let path = '/\'; rm -rf /tmp/wowowowo'
-    })
-  })
-
   describe('absoluteResultsPath', () => {
     var driver = new FsDriver('/tmp')
 
@@ -160,7 +154,7 @@ describe('fs-driver', () => {
     })
 
     it('should use driver.exec to perform file moves', (done) => {
-      var command = 'mv /tmp/foo /tmp/bar'
+      var command = 'mv \'/tmp/foo\' \'/tmp/bar\''
       driver.move('foo', 'bar', () => {
         expect(driver.exec.calledOnce).to.be.true()
         expect(driver.exec.calledWith(command)).to.be.true()
@@ -169,7 +163,7 @@ describe('fs-driver', () => {
     })
 
     it('should use driver.exec to perform file copies', (done) => {
-      var command = 'cp /tmp/foo /tmp/bar'
+      var command = 'cp \'/tmp/foo\' \'/tmp/bar\''
       driver.copy('foo', 'bar', () => {
         expect(driver.exec.calledOnce).to.be.true()
         expect(driver.exec.calledWith(command)).to.be.true()

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -186,6 +186,7 @@ describe('fs-driver', () => {
 
     it('should correctly set the working path', (done) => {
       driver.createWorkingDirectory((err) => {
+        expect(err).to.not.exist()
         expect(driver.workingPath).to.equal(workingPath)
         done()
       })
@@ -357,7 +358,6 @@ describe('fs-driver', () => {
       done()
     })
   }) // end 'absoluteResultsPath'
-
 
   describe('exec', () => {
     var driver = new FsDriver('/root/dir')

--- a/test/fs-driver.js
+++ b/test/fs-driver.js
@@ -14,6 +14,28 @@ var FsDriver = require('../lib/fs-driver')
 var fs = require('fs')
 
 describe('fs-driver', () => {
+  describe('escape', () => {
+    it('should convert non-strings into strings', (done) => {
+      expect(FsDriver.escape({})).to.be.a.string()
+      done()
+    })
+
+    it('should escape single quotes', (done) => {
+      expect(FsDriver.escape('\'')).to.equal('\\\'')
+      done()
+    })
+
+    it('should escape forward slashes', (done) => {
+      expect(FsDriver.escape('/')).to.equal('\\/')
+      done()
+    })
+
+    it('should escape back slahes', (done) => {
+      expect(FsDriver.escape('\\')).to.equal('\\\\')
+      done()
+    })
+  })
+
   describe('constructor', () => {
     it('should construct a new fs driver with a given root', (done) => {
       var root = '/tmp'
@@ -34,6 +56,235 @@ describe('fs-driver', () => {
       done()
     })
   })
+
+  describe('escapePath', () => {
+    var driver = new FsDriver('/tmp')
+
+    it('should return nothing if not given a string', (done) => {
+      expect(driver.escapePath([])).to.equal('')
+      done()
+    })
+
+    it('should remove single quotes', (done) => {
+      expect(driver.escapePath('wowie\'s')).to.match(/wowies/)
+      done()
+    })
+
+    it('should wrap the path in single quotes', (done) => {
+      expect(driver.escapePath('/tmp/neato')).to.equal('\'/tmp/neato\'')
+      done()
+    })
+  }) // end 'escapePath'
+
+  describe('setup', () => {
+    var driver
+    beforeEach((done) => {
+      driver = new FsDriver('/tmp')
+      sinon.stub(driver, 'createWorkingDirectory').yieldsAsync()
+      sinon.stub(driver, 'createResultsDirectory').yieldsAsync()
+      driver.setup(done)
+    })
+
+    it('should create the working directory', (done) => {
+      expect(driver.createWorkingDirectory.calledOnce).to.be.true()
+      done()
+    })
+
+    it('should create the results directory', (done) => {
+      expect(driver.createResultsDirectory.calledOnce).to.be.true()
+      done()
+    })
+  }) // end 'setup'
+
+  describe('teardown', () => {
+    var driver
+    var rootPath
+    var backupPath
+    var workingPath
+    var resultsPath
+
+    beforeEach((done) => {
+      driver = new FsDriver('/tmp')
+      driver.workingPath = '/omg'
+      driver.resultsPath = '/wow'
+      sinon.stub(driver, 'exec').yieldsAsync()
+      rootPath = driver.escapePath(driver.root)
+      backupPath = driver.escapePath(driver.root + '.bak')
+      workingPath = driver.escapePath(driver.workingPath)
+      resultsPath = driver.escapePath(driver.resultsPath)
+      done()
+    })
+
+    describe('with commit', () => {
+      beforeEach((done) => { driver.teardown(true, done) })
+
+      it('should execute the correct commands', (done) => {
+        expect(driver.exec.calledOnce).to.be.true()
+        expect(driver.exec.firstCall.args[0]).to.deep.equal([
+          `mv ${rootPath} ${backupPath}`,
+          `mv ${workingPath} ${rootPath}`,
+          `rm -rf ${backupPath} ${resultsPath}`
+        ].join(' && '))
+        done()
+      })
+    }) // end 'on commit'
+
+    describe('without commit', () => {
+      beforeEach((done) => { driver.teardown(false, done) })
+
+      it('should execute the correct commands', (done) => {
+        expect(driver.exec.calledOnce).to.be.true()
+        expect(driver.exec.firstCall.args[0]).to.deep.equal([
+          `rm -rf ${workingPath}`,
+          `rm -rf ${resultsPath}`
+        ].join(' && '))
+        done()
+      })
+    }) // end 'on commit'
+  }) // end 'teardown'
+
+  describe('createWorkingDirectory', () => {
+    var driver
+    var root = '/tmp/wow'
+    var workingPath
+
+    beforeEach((done) => {
+      driver = new FsDriver(root)
+      sinon.stub(driver, 'exec').yieldsAsync()
+      sinon.stub(driver, 'exists')
+      sinon.stub(Math, 'random').returns('0.9')
+      workingPath = '/tmp/.wow.fs-work.900000'
+      done()
+    })
+
+    afterEach((done) => {
+      Math.random.restore()
+      done()
+    })
+
+    it('should not create if already exists', (done) => {
+      driver.workingPath = 'wowzoa'
+      driver.createWorkingDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.exec.callCount).to.equal(0)
+        done()
+      })
+    })
+
+    it('should copy the root directory to working directory', (done) => {
+      const source = driver.escapePath(driver.root)
+      const dest = driver.escapePath(workingPath)
+      driver.createWorkingDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.exec.calledOnce).to.be.true()
+        expect(driver.exec.calledWith(
+          `cp -r ${source} ${dest}`
+        )).to.be.true()
+        done()
+      })
+    })
+
+    it('should correctly set the working path', (done) => {
+      driver.createWorkingDirectory((err) => {
+        expect(driver.workingPath).to.equal(workingPath)
+        done()
+      })
+    })
+
+    it('should not overwrite existing working directories', (done) => {
+      driver.exists
+        .onFirstCall().returns(true)
+        .onSecondCall().returns(false)
+      Math.random
+        .onFirstCall().returns(0.9)
+        .onSecondCall().returns(0.8)
+      let secondWorkingPath = '/tmp/.wow.fs-work.800000'
+      driver.createWorkingDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.workingPath).to.equal(secondWorkingPath)
+        done()
+      })
+    })
+  }) // end 'createWorkingDirectory'
+
+  describe('createResultsDirectory', () => {
+    var driver
+
+    beforeEach((done) => {
+      driver = new FsDriver('/tmp/neat')
+      sinon.stub(driver, 'exec').yieldsAsync()
+      done()
+    })
+
+    it('should do nothing if the results directory exists', (done) => {
+      driver.resultsPath = 'toteshere'
+      driver.createResultsDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.exec.callCount).to.equal(0)
+        done()
+      })
+    })
+
+    it('should error if the working directory does not exist', (done) => {
+      driver.workingPath = null
+      driver.createResultsDirectory((err) => {
+        expect(err).to.exist()
+        expect(err.message).to.match(/Cannot create/i)
+        expect(driver.exec.callCount).to.equal(0)
+        done()
+      })
+    })
+
+    it('should create the correct results directory', (done) => {
+      driver.workingPath = '/tmp/workingPath.123'
+      let source = driver.escapePath(driver.workingPath)
+      let dest = driver.escapePath(driver.workingPath + '.results')
+      driver.createResultsDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.exec.calledOnce).to.be.true()
+        expect(driver.exec.calledWith(
+          `cp -r ${source} ${dest}`
+        )).to.be.true()
+        done()
+      })
+    })
+
+    it('should set the correct results directory', (done) => {
+      driver.workingPath = '/tmp/workingPath.123'
+      let resultsPath = driver.workingPath + '.results'
+      driver.createResultsDirectory((err) => {
+        expect(err).to.not.exist()
+        expect(driver.resultsPath).to.equal(resultsPath)
+        done()
+      })
+    })
+  }) // end 'createResultsDirectory'
+
+  describe('commitResults', () => {
+    var driver
+
+    beforeEach((done) => {
+      driver = new FsDriver('/wow')
+      driver.workingPath = '/tmp/working'
+      driver.resultsPath = '/tmp/results'
+      sinon.stub(driver, 'exec').yieldsAsync()
+      done()
+    })
+
+    it('should commit the results directory to the working directory', (done) => {
+      const workingPath = driver.escapePath(driver.workingPath)
+      const resultsPath = driver.escapePath(driver.resultsPath)
+      driver.commitResults((err) => {
+        expect(err).to.not.exist()
+        expect(driver.exec.calledOnce).to.be.true()
+        expect(driver.exec.calledWith([
+          `rm -rf ${workingPath}`,
+          `cp -r ${resultsPath} ${workingPath}`
+        ].join(' && '))).to.be.true()
+        done()
+      })
+    })
+  }) // end 'commitResults'
 
   describe('absoluteResultsPath', () => {
     var driver = new FsDriver('/tmp')
@@ -70,6 +321,43 @@ describe('fs-driver', () => {
       done()
     })
   }) // end 'absoluteResultsPath'
+
+  describe('absoluteWorkingPath', () => {
+    var driver = new FsDriver('/tmp')
+
+    it('should return an absolute path for a relative path', (done) => {
+      expect(driver.absoluteWorkingPath('foo.txt'))
+        .to.equal('/tmp/foo.txt')
+      expect(driver.absoluteWorkingPath('./../neat.txt'))
+        .to.equal('/tmp/./../neat.txt')
+      done()
+    })
+
+    it('should return the same path for an absolute path', (done) => {
+      expect(driver.absoluteWorkingPath('/this/path'))
+        .to.equal('/this/path')
+      expect(driver.absoluteWorkingPath('/etc/init.d/../foo'))
+        .to.equal('/etc/init.d/../foo')
+      done()
+    })
+
+    it('should return null if given a non string path', (done) => {
+      expect(driver.absoluteWorkingPath()).to.be.null()
+      expect(driver.absoluteWorkingPath(undefined)).to.be.null()
+      expect(driver.absoluteWorkingPath(null)).to.be.null()
+      expect(driver.absoluteWorkingPath({})).to.be.null()
+      expect(driver.absoluteWorkingPath(42)).to.be.null()
+      done()
+    })
+
+    it('should use the results path if one is present', (done) => {
+      expect(driver.absoluteWorkingPath('foo')).to.equal('/tmp/foo')
+      driver.workingPath = '/etc'
+      expect(driver.absoluteWorkingPath('foo')).to.equal('/etc/foo')
+      done()
+    })
+  }) // end 'absoluteResultsPath'
+
 
   describe('exec', () => {
     var driver = new FsDriver('/root/dir')
@@ -195,7 +483,7 @@ describe('fs-driver', () => {
     describe('diff', () => {
       it('should use driver.exec to perform the diff', (done) => {
         driver.exec.yieldsAsync(null, 'diff', 'command')
-        var command = 'diff -u -r /tmp/a /tmp/b'
+        var command = 'diff -u -r \'/tmp/a\' \'/tmp/b\''
         driver.diff('/tmp/a', '/tmp/b', (err) => {
           expect(err).to.not.exist()
           expect(driver.exec.calledOnce).to.be.true()
@@ -246,20 +534,12 @@ describe('fs-driver', () => {
       })
     })
 
-    it('should use driver.exec to remove files', (done) => {
-      var command = 'rm /tmp/file1.txt'
-      driver.remove('file1.txt', () => {
-        expect(driver.exec.calledOnce).to.be.true()
-        expect(driver.exec.calledWith(command)).to.be.true()
-        done()
-      })
-    })
-
-    it('should use driver.exec to recursively remove files', (done) => {
-      var command = 'rm -rf /tmp/dir/'
-      driver.removeRecursive('dir/', () => {
-        expect(driver.exec.calledOnce).to.be.true()
-        expect(driver.exec.calledWith(command)).to.be.true()
+    it('should call `diff` when computing the `resultsDiff`', (done) => {
+      sinon.stub(driver, 'diff').yieldsAsync()
+      driver.resultsDiff((err, result) => {
+        if (err) { return done(err) }
+        expect(driver.diff.calledWith(driver.workingPath, driver.resultsPath))
+          .to.be.true()
         done()
       })
     })

--- a/test/functional.js
+++ b/test/functional.js
@@ -173,30 +173,6 @@ describe('functional', () => {
         expect(linesC[5]).to.equal('Woof')
         expect(linesC[7]).to.equal('Woof')
         expect(dataB.match('Woof')).to.be.null()
-        expect(transformer.warnings).to.not.be.empty()
-        expect(transformer.warnings[0].message)
-          .to.equal('Unused exclude.')
-        done()
-      })
-    })
-
-    it('should warn if excludes all results', (done) => {
-      var search = 'File A'
-      var replace = 'File X'
-      var rules = [{
-        action: 'replace',
-        search: search,
-        replace: replace,
-        exclude: ['A']
-      }]
-      Transformer.transform(fs.path, rules, (err, transformer) => {
-        if (err) { return done(err) }
-        var dataA = fs.read('A')
-        expect(dataA.match(search)).to.not.be.null()
-        expect(dataA.match(replace)).to.be.null()
-        expect(transformer.warnings).to.not.be.empty()
-        expect(transformer.warnings[0].message)
-          .to.equal('All results were excluded.')
         done()
       })
     })

--- a/test/functional.js
+++ b/test/functional.js
@@ -176,6 +176,19 @@ describe('functional', () => {
         done()
       })
     })
+
+    it('should correctly set diffs by filename', (done) => {
+      var rules = [
+        { action: 'replace', search: 'Exampel', replace: 'Shamp' }
+      ]
+      Transformer.transform(fs.path, rules, (err, transformer) => {
+        if (err) { return done(err) }
+        let result = transformer.results[0]
+        expect(result.diffs['/A'].startsWith('--- /A')).to.be.true()
+        expect(result.diffs['/B'].startsWith('--- /B')).to.be.true()
+        done()
+      })
+    })
   }) // end 'replace'
 
   describe('results', () => {

--- a/test/transformer/exclude.js
+++ b/test/transformer/exclude.js
@@ -56,7 +56,7 @@ describe('Transformer', () => {
         files: ['A.txt', 'B.txt', 'C.txt']
       }
       var expectedFiles = rule.files.map((file) => {
-        return transformer.driver.absolutePath(file)
+        return transformer.driver.absoluteWorkingPath(file)
       })
       transformer.exclude(rule, (err) => {
         if (err) { return done(err) }

--- a/test/transformer/replace.js
+++ b/test/transformer/replace.js
@@ -1,51 +1,45 @@
 'use strict'
 
-var Lab = require('lab')
-var lab = exports.lab = Lab.script()
-var describe = lab.describe
-var it = lab.it
-var beforeEach = lab.beforeEach
-var Code = require('code')
-var expect = Code.expect
-var sinon = require('sinon')
-var noop = require('101/noop')
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const describe = lab.describe
+const it = lab.it
+const beforeEach = lab.beforeEach
+const afterEach = lab.afterEach
+const Code = require('code')
+const expect = Code.expect
+const sinon = require('sinon')
 
-var Transformer = require('../../lib/transformer')
+const Transformer = require('../../lib/transformer')
+const Replacer = require('../../lib/replacer')
 
 describe('Transformer', () => {
   describe('replace', () => {
     var transformer
+
     beforeEach((done) => {
       transformer = new Transformer('/etc', [])
+      sinon.stub(Replacer, 'findAndReplace').returns(Promise.resolve())
+      sinon.stub(transformer.driver, 'resultsDiff').yieldsAsync(null, [
+        'diff -u -r /foo /foo',
+        'some diff info',
+        'diff -u -r /bar /bar',
+        'some more',
+        'diff info'
+      ].join('\n'))
+      done()
+    })
+
+    afterEach((done) => {
+      Replacer.findAndReplace.restore()
       done()
     })
 
     describe('warnings', () => {
-      var grepSpy
-      var sedSpy
-      var copySpy
-      var removeSpy
-      var diffSpy
-
-      beforeEach((done) => {
-        transformer = new Transformer('/etc', [])
-        grepSpy = sinon.spy(transformer.driver, 'grep')
-        sedSpy = sinon.spy(transformer.driver, 'sed')
-        copySpy = sinon.spy(transformer.driver, 'copy')
-        removeSpy = sinon.spy(transformer.driver, 'remove')
-        diffSpy = sinon.spy(transformer.driver, 'diff')
-        done()
-      })
-
       it('should add a warning and do nothing if not given a search pattern', (done) => {
         var rule = {}
         transformer.replace(rule, (err) => {
           if (err) { return done(err) }
-          expect(grepSpy.callCount).to.equal(0)
-          expect(sedSpy.callCount).to.equal(0)
-          expect(copySpy.callCount).to.equal(0)
-          expect(removeSpy.callCount).to.equal(0)
-          expect(diffSpy.callCount).to.equal(0)
           expect(transformer.warnings.length).to.equal(1)
           var warning = transformer.warnings[0]
           expect(warning.rule).to.equal(rule)
@@ -58,11 +52,6 @@ describe('Transformer', () => {
         var rule = { search: 'a' }
         transformer.replace(rule, (err) => {
           if (err) { return done(err) }
-          expect(grepSpy.callCount).to.equal(0)
-          expect(sedSpy.callCount).to.equal(0)
-          expect(copySpy.callCount).to.equal(0)
-          expect(removeSpy.callCount).to.equal(0)
-          expect(diffSpy.callCount).to.equal(0)
           expect(transformer.warnings.length).to.equal(1)
           var warning = transformer.warnings[0]
           expect(warning.rule).to.equal(rule)
@@ -73,8 +62,8 @@ describe('Transformer', () => {
 
       it('should add a warning if excludes is not an array', (done) => {
         var rule = { search: 'a', replace: 'b', exclude: 1776 }
-        transformer.driver.grep.restore()
-        sinon.stub(transformer.driver, 'grep', () => {
+        transformer.replace(rule, (err) => {
+          expect(err).to.not.exist()
           expect(transformer.warnings.length).to.equal(1)
           var warning = transformer.warnings[0]
           expect(warning.rule).to.equal(rule)
@@ -82,357 +71,65 @@ describe('Transformer', () => {
             .to.equal('Excludes not supplied as an array, omitting.')
           done()
         })
-        transformer.replace(rule)
-      })
-
-      it('should add a warning and do nothing if no files match the pattern', (done) => {
-        var rule = { search: 'a', replace: 'b' }
-        transformer.driver.grep.restore()
-        sinon.stub(transformer.driver, 'grep').yields(null, '')
-        transformer.replace(rule, (err) => {
-          if (err) { return done(err) }
-          expect(transformer.warnings.length).to.equal(1)
-          var warning = transformer.warnings[0]
-          expect(warning.rule).to.equal(rule)
-          expect(warning.message)
-            .to.equal('Search did not return any results.')
-          expect(copySpy.callCount).to.equal(0)
-          done()
-        })
       })
     }) // end 'warnings'
 
-    it('should perform a grep for the search and replace', (done) => {
-      var rule = { action: 'replace', search: 'a', replace: 'b' }
-      var grep = sinon.stub(transformer.driver, 'grep', () => {
-        expect(grep.calledOnce).to.be.true()
-        expect(grep.calledWith(rule.search)).to.be.true()
-        transformer.driver.grep.restore()
-        done()
-      })
-      transformer.replace(rule, noop)
-    })
-
-    it('should not proceed if grep fails', (done) => {
-      var rule = { action: 'replace', search: 'a', replace: 'b' }
-      var grepError = new Error('Grep error')
-      sinon.stub(transformer.driver, 'grep').yields(grepError)
-      transformer.replace(rule, (err) => {
-        expect(err).to.equal(grepError)
-        done()
-      })
-    })
-
-    it('should call sed on each file in the result set', (done) => {
-      var sed = sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt'
-      ].join('\n'))
-
-      var rule = { action: 'replace', search: 'a', replace: 'b' }
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        expect(sed.callCount).to.equal(2)
-        expect(sed.calledWith('a', 'b', '/etc/file1.txt')).to.be.true()
-        expect(sed.calledWith('a', 'b', '/etc/file2.txt')).to.be.true()
-        done()
-      })
-    })
-
-    it('should apply global file excludes', (done) => {
-      var rule = { search: 'koopa', replace: 'mario' }
-      transformer.exclude({ files: ['file2.txt', 'file4.txt'] }, noop)
-
-      var sed = sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt',
-        '/etc/file4.txt',
-        '/etc/suhweet/file4.txt'
-      ].join('\n'))
-
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        expect(sed.callCount).to.equal(3)
-        expect(sed.calledWith('koopa', 'mario', '/etc/file1.txt'))
-          .to.be.true()
-        expect(sed.calledWith('koopa', 'mario', '/etc/file3.txt'))
-          .to.be.true()
-        expect(sed.calledWith('koopa', 'mario', '/etc/suhweet/file4.txt'))
-          .to.be.true()
-        done()
-      })
-    })
-
-    it('should always exclude .git files', (done) => {
-      var rule = { search: 'metroid', replace: 'samus' }
-      var sed = sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/.git/file1.txt',
-        '/etc/.git/file2.txt',
-        '/etc/file3.txt',
-        '/etc/file4.txt'
-      ].join('\n'))
-
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        expect(sed.callCount).to.equal(2)
-        expect(sed.calledWith('metroid', 'samus', '/etc/.git/file1.txt'))
-          .to.be.false()
-        expect(sed.calledWith('metroid', 'samus', '/etc/.git/file2.txt'))
-          .to.be.false()
-        expect(sed.calledWith('metroid', 'samus', '/etc/file3.txt'))
-          .to.be.true()
-        expect(sed.calledWith('metroid', 'samus', '/etc/file4.txt'))
-          .to.be.true()
-        done()
-      })
-    })
-
-    it('should appropriately apply exclude filters', (done) => {
-      var rule = {
-        search: 'a',
-        replace: 'b',
-        exclude: [
-          'file1.txt',
-          'file2.txt',
-          'not-there.txt'
-        ]
+    describe('Replacer', () => {
+      const workingPath = '/tmp/working/path'
+      const resultsPath = '/tmp/results/path'
+      const globalExcludes = ['.some.file', '.some.other.file']
+      const rule = {
+        search: 'search string yo',
+        replace: 'replace string bro',
+        exclude: ['one.txt', 'two.txt']
       }
 
-      var sed = sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt'
-      ].join('\n'))
+      beforeEach((done) => {
+        transformer.driver.workingPath = workingPath
+        transformer.driver.resultsPath = resultsPath
+        transformer._globalExcludes = globalExcludes
+        sinon.stub(transformer.script, 'addRule')
+        sinon.stub(transformer, 'setFileDiff')
+        transformer.replace(rule, done)
+      })
 
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        expect(sed.callCount).to.equal(1)
-        expect(sed.calledWith('a', 'b', '/etc/file3.txt')).to.be.true()
+      it('should call the findAndReplace method', (done) => {
+        expect(Replacer.findAndReplace.calledOnce).to.be.true()
+        expect(Replacer.findAndReplace.firstCall.args).to.deep.equal([
+          transformer.driver.workingPath,
+          transformer.driver.resultsPath,
+          globalExcludes.concat(rule.exclude),
+          rule.search,
+          rule.replace
+        ])
         done()
       })
-    })
 
-    it('should add a warning for every exclude that was not applied', (done) => {
-      var rule = {
-        search: 'a',
-        replace: 'b',
-        exclude: [
-          'applied.txt',
-          'not-there',
-          'file1.txt'
-        ]
-      }
-
-      sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/applied.txt',
-        '/etc/okay.txt',
-        '/etc/file1.txt'
-      ].join('\n'))
-
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        var warnings = transformer.warnings
-        expect(warnings.length).to.equal(1)
-        expect(warnings[0].rule).to.equal(rule.exclude[1])
-        expect(warnings[0].message).to.equal('Unused exclude.')
-        done()
-      })
-    })
-
-    it('should add a warning and skip if all results were excluded', (done) => {
-      var rule = {
-        search: 'a',
-        replace: 'b',
-        exclude: ['file1.txt']
-      }
-
-      var sed = sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file1.txt',
-        '/etc/file1.txt'
-      ].join('\n'))
-
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        var warnings = transformer.warnings
-        expect(warnings.length).to.equal(1)
-        expect(warnings[0].rule).to.equal(rule)
-        expect(warnings[0].message).to.equal('All results were excluded.')
-        expect(sed.callCount).to.equal(0)
-        done()
-      })
-    })
-
-    it('should make an original copy for each changed file', (done) => {
-      var rule = {
-        action: 'replace',
-        search: 'awesome',
-        replace: 'super'
-      }
-
-      var copy = sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'sed').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt'
-      ].join('\n'))
-
-      var fileNames = [
-        '/etc/file.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt'
-      ]
-
-      transformer.replace(rule, (err) => {
-        if (err) { return done(err) }
-        expect(copy.callCount).to.equal(3)
-        fileNames.forEach((name) => {
-          expect(copy.calledWith(name, name + Transformer.ORIGINAL_POSTFIX))
-            .to.be.true()
-        })
-        done()
-      })
-    })
-
-    it('should not proceed on original copy error', (done) => {
-      var rule = {
-        action: 'replace',
-        search: 'awesome',
-        replace: 'super'
-      }
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file.txt',
-        '/etc/file.txt'
-      ].join('\n'))
-      var sed = sinon.stub(transformer.driver, 'sed')
-        .returns('command')
-        .yields()
-      var copyError = new Error('Copy error')
-      sinon.stub(transformer.driver, 'copy').yieldsAsync(copyError)
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'diff').yields()
-
-      transformer.replace(rule, (err) => {
-        expect(err).to.equal(copyError)
-        expect(sed.callCount).to.equal(0)
-        done()
-      })
-    })
-
-    it('should yield an error if diff actually failed (code > 1)', (done) => {
-      var rule = {
-        action: 'replace',
-        search: 'alpha',
-        replace: 'beta'
-      }
-
-      var error = new Error('Totally a real error')
-      error.code = 3
-      var diff = sinon.stub(transformer.driver, 'diff').yields(error)
-      sinon.stub(transformer.driver, 'sed').yieldsAsync()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'remove').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file2.txt'
-      ].join('\n'))
-
-      transformer.replace(rule, (err) => {
-        expect(err).to.not.be.null()
-        expect(diff.callCount).to.equal(1)
-        done()
-      })
-    })
-
-    it('should remove original copies', (done) => {
-      var rule = {
-        action: 'replace',
-        search: 'alpha',
-        replace: 'beta'
-      }
-      var remove = sinon.stub(transformer.driver, 'remove').yieldsAsync()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'sed').yieldsAsync()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt'
-      ].join('\n'))
-
-      var filenames = [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt'
-      ]
-
-      transformer.replace(rule, () => {
-        expect(remove.callCount).to.equal(3)
-        filenames.forEach((name) => {
-          var originalName = name + Transformer.ORIGINAL_POSTFIX
-          var dotLastName = name + '.last'
-          expect(remove.calledWith(originalName + ' ' + dotLastName))
-            .to.be.true()
-        })
-        done()
-      })
-    })
-
-    it('should only add the rule to the result script once', (done) => {
-      var rule = {
-        action: 'replace',
-        search: 'darn',
-        replace: 'yankees'
-      }
-      sinon.stub(transformer.driver, 'remove').yieldsAsync()
-      sinon.stub(transformer.driver, 'diff').yields()
-      sinon.stub(transformer.driver, 'sed').yieldsAsync()
-      sinon.stub(transformer.driver, 'copy').yields()
-      sinon.stub(transformer.driver, 'grep').yields(null, [
-        '/etc/file1.txt',
-        '/etc/file2.txt',
-        '/etc/file3.txt',
-        '/etc/file4.txt',
-        '/etc/file5.txt',
-        '/etc/file6.txt'
-      ].join('\n'))
-
-      sinon.spy(transformer.script, 'addRule')
-
-      transformer.replace(rule, () => {
+      it('should add the rule to the results', (done) => {
         expect(transformer.script.addRule.calledOnce).to.be.true()
+        expect(transformer.script.addRule.calledWith(rule)).to.be.true()
         done()
       })
-    })
+
+      it('should construct the results diff', (done) => {
+        expect(transformer.setFileDiff.calledWith('/foo'), [
+          'some diff info'
+        ].join('\n')).to.be.true()
+        expect(transformer.setFileDiff.calledWith('/foo'), [
+          'some more',
+          'diff info'
+        ].join('\n')).to.be.true()
+        done()
+      })
+
+      it('should yield an error if the results diff yields and error', (done) => {
+        const error = new Error('no diffs woooooo')
+        transformer.driver.resultsDiff.yields(error)
+        transformer.replace(rule, (err) => {
+          expect(err).to.equal(error)
+          done()
+        })
+      })
+    }) // end 'Replacer'
   }) // end 'replace'
-})
+}) // end 'Transformer'


### PR DESCRIPTION
This is a major security patch for find-and-replace via fs-transform. This removes the use of `childProcess.exec` with direct user input. From now on, when `exec` is used, it is used only on internal commands that reference working paths, etc.

- [x] @bkendall 