### PR TITLE
SAN-3826; Better Handling of Special Characters in Script "Replace"

### DIFF
--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -30,7 +30,9 @@ class FsDriver {
     if (!isString(str)) {
       str = str.toString()
     }
-    return str.replace(/(['/\\])/g, '\\$1')
+    return str.replace(/'/g, '\'"\'"\'')
+      .replace(/[\\]/g, '\\\\')
+      .replace(/([/])/g, '\\$1')
   }
 
   /**
@@ -281,13 +283,6 @@ class FsDriver {
           self.root + '$1'
         )
       }
-
-      if (err && err.code === 'ENOENT') {
-        err.cmd = cmd
-        err.args = args
-        err.scriptCommand = scriptCommand
-      }
-
       cb(err, output, scriptCommand)
     })
   }

--- a/lib/fs-driver.js
+++ b/lib/fs-driver.js
@@ -30,6 +30,7 @@ class FsDriver {
     if (!isString(str)) {
       str = str.toString()
     }
+    // See Stackoverflow: http://goo.gl/dDeRQY
     return str.replace(/'/g, '\'"\'"\'')
       .replace(/[\\]/g, '\\\\')
       .replace(/([/])/g, '\\$1')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-transform",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Fast, rule based, file system transformations.",
   "main": "index.js",
   "scripts": {

--- a/script/preamble.sh
+++ b/script/preamble.sh
@@ -78,7 +78,7 @@ function copy {
 function replace {
   local git_pattern='.git/'
   log "Rule $rule_count: Replacing instances of '$1' with '$2'"
-  for name in $(eval "grep -rlI '$1' .")
+  for name in $(grep -rlI "$1" .)
   do
     # Always exclude .git/ files
     if [[ $name =~ $git_pattern ]]; then continue; fi

--- a/test/fixtures/root/E
+++ b/test/fixtures/root/E
@@ -1,0 +1,3 @@
+File E
+
+'username' => ''

--- a/test/fixtures/script.sh
+++ b/test/fixtures/script.sh
@@ -78,7 +78,7 @@ function copy {
 function replace {
   local git_pattern='.git/'
   log "Rule $rule_count: Replacing instances of '$1' with '$2'"
-  for name in $(eval "grep -rlI '$1' .")
+  for name in $(grep -rlI "$1" .)
   do
     # Always exclude .git/ files
     if [[ $name =~ $git_pattern ]]; then continue; fi

--- a/test/functional/script.js
+++ b/test/functional/script.js
@@ -1,0 +1,122 @@
+'use strict'
+
+var Lab = require('lab')
+var lab = exports.lab = Lab.script()
+var describe = lab.describe
+var it = lab.it
+var before = lab.before
+var beforeEach = lab.beforeEach
+var after = lab.after
+var afterEach = lab.afterEach
+var Code = require('code')
+var expect = Code.expect
+var fs = require('../fixtures/fs-helper')
+var async = require('async')
+var childProcess = require('child_process')
+
+var debug = require('debug')('fs-transform:test')
+
+var Transformer = require('../../index')
+
+describe('functional', () => {
+  describe('script', () => {
+    const scriptPath = fs.mock + '.script'
+
+    before(fs.createDotGit)
+    after(fs.removeDotGit)
+
+    beforeEach(fs.createTestDir)
+    afterEach(fs.removeTestDir)
+
+    beforeEach((done) => {
+      childProcess.execFile('cp', ['-r', fs.mock, scriptPath], done)
+    })
+
+    afterEach((done) => {
+      var command = 'rm -rf ' + scriptPath
+      childProcess.exec(command, {cwd: 'test/fixtures/'}, done)
+    })
+
+    function compareScript (rules, done) {
+      var script
+      async.series([
+        function generateScript (next) {
+          Transformer.transform(fs.path, rules, (err, transformer) => {
+            if (err) { return next(err) }
+            script = transformer.getScript()
+            debug(script)
+            fs.writeFile(scriptPath + '/script.sh', script, next)
+          })
+        },
+        function runScript (next) {
+          const opts = { cwd: scriptPath }
+          childProcess.exec('bash script.sh', opts, (err, output) => {
+            debug(output)
+            next(err)
+          })
+        },
+        function removeScript (next) {
+          childProcess.exec('rm -f ' + scriptPath + '/script.sh', next)
+        },
+        function getDiff (next) {
+          var command = 'diff -r ' + fs.path + ' ' + scriptPath
+          childProcess.exec(command, (err, diff) => {
+            if (err && err.code > 1) { return next(err) }
+            debug(diff)
+            expect(diff).to.be.empty()
+            next()
+          })
+        }
+      ], done)
+    }
+
+    it('should correctly handle global excludes', (done) => {
+      compareScript([
+        { action: 'exclude', files: ['sub/C', 'A'] },
+        { action: 'replace', search: 'Mew', replace: 'Woof' }
+      ], done)
+    })
+
+    it('should handle local replace excludes', (done) => {
+      compareScript([
+        {
+          action: 'replace',
+          search: 'Mew',
+          replace: 'Bark',
+          exclude: ['sub/C']
+        }
+      ], done)
+    })
+
+    it('should always exclude .git files', (done) => {
+      compareScript([
+        { action: 'replace', search: 'only_in_gitfile', replace: 'yus' }
+      ], done)
+    })
+
+    it('should handle single quotes', (done) => {
+      compareScript([
+        {
+          action: 'replace',
+          search: '\'username\' => \'\'',
+          replace: '\'username\' => \'wowzers\''
+        }
+      ], done)
+    })
+
+    it('should handle backslashes', (done) => {
+      compareScript([
+        { action: 'replace', search: '\\sum', replace: '\\prod' }
+      ], done)
+    })
+
+    it('should handle multiple transforms', (done) => {
+      compareScript([
+        { action: 'replace', search: '\\sum', replace: '\\prod' },
+        { action: 'copy', source: 'A', dest: 'A-copy' },
+        { action: 'copy', source: 'B', dest: 'B-copy' },
+        { action: 'rename', source: 'sub/C', dest: 'sub/C-rename' }
+      ], done)
+    })
+  }) // end 'script'
+}) // end 'functional'

--- a/test/unit/fs-driver.js
+++ b/test/unit/fs-driver.js
@@ -21,7 +21,7 @@ describe('fs-driver', () => {
     })
 
     it('should escape single quotes', (done) => {
-      expect(FsDriver.escape('\'')).to.equal('\\\'')
+      expect(FsDriver.escape('\'')).to.equal('\'"\'"\'')
       done()
     })
 


### PR DESCRIPTION
Modifies the output script to handle the following:
- Allows for single quotes
- Better handling of backslashes
- Better execution of grep (without eval)

Also factored out the script tests so it is easier to test specific functional cases.
### Reviewers
- [x] @Myztiq 
- [x] @podviaznikov 
